### PR TITLE
Extract script test Ruby checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ The repo is public. Treat every committed byte as public-facing.
 - `script/doctor`: Checks local command availability, manifest validity, managed-file
   health, and install state.
 - `script/test`: The repo-native validation entrypoint. Run this before pushing.
+- `script/test-check`: Ruby validation helper called by `script/test` for
+  JSONC, YAML, supply-chain, workflow, fixture, and public-safety checks.
 - `script/manifest`: Ruby helper for validating and printing `install.yml`.
 - `lib/dotfiles/manifest.rb`: Manifest parser and validation logic.
 - `lib/dotfiles/installer.rb`: Ruby implementation behind `script/install`.
@@ -49,6 +51,9 @@ The repo is public. Treat every committed byte as public-facing.
 - `lib/dotfiles/doctor.rb`: Ruby implementation behind `script/doctor`.
 - `lib/dotfiles/runtime.rb`: Small shared runtime helpers for command checks,
   path selection, timestamps, and restrained color formatting.
+- `lib/dotfiles/test_checks.rb`: Test-time validators used by
+  `script/test-check`. Keep validation logic here rather than embedding Ruby in
+  Bash scripts.
 - `script/vscode`: Strict VS Code desired-state manager with `validate`, `plan`,
   `apply`, and `doctor` subcommands.
 - `script/vsc-extension-bulk-install`: Compatibility wrapper around
@@ -261,6 +266,10 @@ The current preference is:
   `script/vsc-extension-bulk-install` are Ruby entrypoints.
 - Keep Bash for shell startup/configuration and for `script/test` orchestration
   where it is intentionally exercising shell behavior.
+- Do not embed Ruby programs in Bash scripts with heredocs, `ruby -e`, or
+  similar inline snippets when the logic can live in a dedicated Ruby file.
+  Put that code in `lib/dotfiles/` or a Ruby `script/` entrypoint and cover it
+  with RSpec.
 - Use Ruby stdlib whenever possible.
 - Keep `Gemfile` minimal.
 - Keep `rspec` as the only top-level development gem unless the owner approves

--- a/lib/dotfiles/test_checks.rb
+++ b/lib/dotfiles/test_checks.rb
@@ -1,0 +1,416 @@
+# frozen_string_literal: true
+
+require "bundler"
+require "English"
+require "json"
+require "yaml"
+
+require_relative "manifest"
+
+module Dotfiles
+  module TestChecks
+    class Error < StandardError; end
+
+    module JSONC
+      module_function
+
+      def validate_file(path)
+        JSON.parse(strip(File.read(path)))
+        true
+      rescue JSON::ParserError => e
+        raise Error, "#{path}: invalid JSON/JSONC: #{e.message}"
+      rescue Errno::ENOENT
+        raise Error, "#{path}: file not found"
+      end
+
+      def strip(text)
+        out = +""
+        in_string = false
+        escape = false
+        chars = text.each_char.to_a
+        index = 0
+
+        while index < chars.length
+          char = chars[index]
+
+          if in_string
+            out << char
+            if escape
+              escape = false
+            elsif char == "\\"
+              escape = true
+            elsif char == '"'
+              in_string = false
+            end
+          elsif char == '"'
+            in_string = true
+            out << char
+          elsif char == "/" && chars[index + 1] == "/"
+            index += 2
+            index += 1 while index < chars.length && chars[index] != "\n"
+            out << "\n" if index < chars.length
+          elsif char == "/" && chars[index + 1] == "*"
+            index = consume_block_comment(chars, index, out)
+          else
+            out << char
+          end
+
+          index += 1
+        end
+
+        out.gsub(/,\s*([}\]])/, '\1')
+      end
+
+      def consume_block_comment(chars, index, out)
+        index += 2
+        closed = false
+        while index < chars.length
+          if chars[index] == "*" && chars[index + 1] == "/"
+            index += 1
+            closed = true
+            break
+          end
+          out << "\n" if chars[index] == "\n"
+          index += 1
+        end
+        raise Error, "unterminated block comment" unless closed
+
+        index
+      end
+    end
+
+    module YAMLCheck
+      module_function
+
+      def validate_file(path)
+        YAML.safe_load(File.read(path), permitted_classes: [], permitted_symbols: [], aliases: false)
+        true
+      rescue Psych::Exception => e
+        raise Error, "#{path}: invalid YAML: #{e.message}"
+      rescue Errno::ENOENT
+        raise Error, "#{path}: file not found"
+      end
+    end
+
+    module BundlerSupplyChain
+      module_function
+
+      def validate(root)
+        failures = []
+        failures.concat(validate_config(root))
+        lock_text = File.read(File.join(root, "Gemfile.lock"))
+        failures.concat(validate_lockfile(lock_text, root))
+        raise Error, failures.join("\n") unless failures.empty?
+
+        true
+      rescue Errno::ENOENT => e
+        raise Error, e.message
+      end
+
+      def validate_config(root)
+        config_path = File.join(root, ".bundle/config")
+        config = YAML.safe_load(File.read(config_path), permitted_classes: [], permitted_symbols: [], aliases: false)
+        return [] if config.fetch("BUNDLE_FROZEN", nil) == "true"
+
+        [".bundle/config must set BUNDLE_FROZEN: \"true\""]
+      end
+
+      def validate_lockfile(lock_text, root)
+        failures = []
+        unless lock_text.match?(/\ACHECKSUMS\n|\nCHECKSUMS\n/)
+          failures << "Gemfile.lock is missing CHECKSUMS"
+        end
+
+        checksum_entries, checksum_failures = checksum_entries(lock_text)
+        failures.concat(checksum_failures)
+        specs = Bundler::LockfileParser.new(lock_text).specs
+        failures.concat(validate_spec_checksums(specs, checksum_entries))
+        failures.concat(validate_cached_gems(specs, root))
+        failures
+      end
+
+      def checksum_entries(lock_text)
+        entries = {}
+        failures = []
+        in_checksums = false
+        lock_text.each_line do |line|
+          stripped = line.chomp
+          if stripped == "CHECKSUMS"
+            in_checksums = true
+            next
+          end
+          next unless in_checksums
+          break if stripped.match?(/\A[A-Z][A-Z ]*\z/)
+          next if stripped.empty?
+
+          match = stripped.match(/\A  (?<name>.+) \((?<version>[^)]+)\) sha256=(?<sha>[0-9a-f]{64})\z/)
+          if match
+            entries[[match[:name], match[:version]]] = match[:sha]
+          else
+            failures << "invalid Gemfile.lock checksum line: #{stripped}"
+          end
+        end
+        [entries, failures]
+      end
+
+      def validate_spec_checksums(specs, checksum_entries)
+        specs.filter_map do |spec|
+          version = checksum_version(spec)
+          next if checksum_entries.key?([spec.name, version])
+
+          "missing checksum for #{spec.name} (#{version})"
+        end
+      end
+
+      def checksum_version(spec)
+        platform = spec.platform.to_s
+        platform == "ruby" ? spec.version.to_s : "#{spec.version}-#{platform}"
+      end
+
+      def validate_cached_gems(specs, root)
+        cache_dir = File.join(root, "vendor/cache")
+        expected_cache = specs.map { |spec| "#{spec.full_name}.gem" }.sort
+        actual_cache = Dir.exist?(cache_dir) ? Dir.children(cache_dir).grep(/\.gem\z/).sort : []
+        failures = []
+        (expected_cache - actual_cache).each { |gem| failures << "missing cached gem: vendor/cache/#{gem}" }
+        (actual_cache - expected_cache).each { |gem| failures << "extra cached gem: vendor/cache/#{gem}" }
+        failures
+      end
+    end
+
+    module CIWorkflowActionPins
+      module_function
+
+      def validate(root)
+        failures = []
+        workflow_paths(root).each do |path|
+          failures.concat(validate_file(root, path))
+        end
+        raise Error, failures.join("\n") unless failures.empty?
+
+        true
+      end
+
+      def workflow_paths(root)
+        Dir[File.join(root, ".github/workflows/*.{yml,yaml}")].sort
+      end
+
+      def validate_file(root, path)
+        failures = []
+        File.readlines(path).each_with_index do |line, index|
+          match = line.match(/\buses:\s*['"]?(?<uses>[^'"\s#]+)['"]?/)
+          next unless match
+
+          value = match[:uses]
+          next if value.start_with?("./")
+          next if pinned_action_ref?(value)
+
+          relative = path.delete_prefix("#{root}/")
+          failures << "#{relative}:#{index + 1} action is not SHA-pinned: #{value}"
+        end
+        failures
+      end
+
+      def pinned_action_ref?(value)
+        if value.start_with?("docker://")
+          value.match?(/@sha256:[0-9a-f]{64}\z/i)
+        else
+          value.match?(/@[0-9a-f]{40}\z/i)
+        end
+      end
+    end
+
+    module VSCodeFixturePlan
+      module_function
+
+      def validate(json)
+        plan = JSON.parse(json).fetch("actions")
+        assertions.each do |message, assertion|
+          raise Error, message unless assertion.call(plan)
+        end
+        true
+      rescue JSON::ParserError => e
+        raise Error, "fixture plan is invalid JSON: #{e.message}"
+      rescue KeyError
+        raise Error, "fixture plan is missing actions"
+      end
+
+      def assertions
+        [
+          ["fixture should update non-auto-update drift", ->(plan) { action_for(plan, "extension", "update", id: "donjayamanne.githistory") }],
+          ["fixture should install missing baseline extension", ->(plan) { action_for(plan, "extension", "install", id: "hashicorp.terraform") }],
+          ["fixture should keep auto-updated ChatGPT", ->(plan) { action_for(plan, "extension", "keep_auto_update", id: "openai.chatgpt") }],
+          ["fixture should keep auto-updated Copilot Chat", ->(plan) { action_for(plan, "extension", "keep_auto_update", id: "github.copilot-chat") }],
+          ["fixture should prune untracked extension", ->(plan) { action_for(plan, "extension", "prune", id: "untracked.publisher") }],
+          ["fixture should configure selected auto-update allowlist", method(:valid_auto_update_allowlist?)],
+          ["fixture should deny auto-update for tracked non-allowlisted extensions", method(:valid_auto_update_denylist?)],
+          ["fixture should pin non-auto-update extensions in extensions.allowed", method(:valid_extensions_allowed_pin?)],
+          ["fixture should allow only stable auto-update exceptions in extensions.allowed", method(:valid_extensions_allowed_stable?)],
+        ]
+      end
+
+      def action_for(plan, type, action, id: nil, key: nil)
+        plan.find do |entry|
+          entry["type"] == type &&
+            entry["action"] == action &&
+            (id.nil? || entry["id"] == id) &&
+            (key.nil? || entry["key"] == key)
+        end
+      end
+
+      def valid_auto_update_allowlist?(plan)
+        allowlist = action_for(plan, "storage", "configure", key: "extensions.autoUpdate")
+        allowlist && allowlist.fetch("desired") == ["github.copilot-chat", "github.vscode-github-actions", "openai.chatgpt"]
+      end
+
+      def valid_auto_update_denylist?(plan)
+        denylist = action_for(plan, "storage", "configure", key: "extensions.donotAutoUpdate")
+        desired = denylist&.fetch("desired", nil)
+        desired &&
+          desired.include?("donjayamanne.githistory") &&
+          !desired.include?("openai.chatgpt") &&
+          !desired.include?("github.copilot-chat") &&
+          !desired.include?("github.vscode-github-actions")
+      end
+
+      def extensions_allowed_action(plan)
+        action_for(plan, "setting", "keep", key: "extensions.allowed") ||
+          action_for(plan, "setting", "write", key: "extensions.allowed")
+      end
+
+      def valid_extensions_allowed_pin?(plan)
+        allowed = extensions_allowed_action(plan)
+        allowed && allowed.fetch("desired").fetch("donjayamanne.githistory") == ["0.6.20"]
+      end
+
+      def valid_extensions_allowed_stable?(plan)
+        allowed = extensions_allowed_action(plan)
+        allowed &&
+          allowed.fetch("desired").fetch("openai.chatgpt") == "stable" &&
+          allowed.fetch("desired").fetch("github.copilot-chat") == "stable" &&
+          allowed.fetch("desired").fetch("github.vscode-github-actions") == "stable"
+      end
+    end
+
+    module PublicSafety
+      module_function
+
+      SECRET_PATTERNS = [
+        /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+        /AKIA[0-9A-Z]{16}/,
+        /gh[pousr]_[A-Za-z0-9_]{36,}/,
+        /xox[baprs]-[A-Za-z0-9-]{20,}/,
+        /sk-[A-Za-z0-9]{32,}/,
+        /(?:api[_-]?key|access[_-]?token|client[_-]?secret|refresh[_-]?token)\s*[:=]\s*["']?[A-Za-z0-9_\.\/+=-]{20,}/i
+      ].freeze
+
+      def validate(root, tracked_files: nil)
+        tracked_files ||= git_tracked_files(root)
+        failures = []
+        failures.concat(blocked_vscode_paths(tracked_files))
+        failures.concat(sensitive_generated_paths(tracked_files))
+        failures.concat(secret_pattern_failures(root, tracked_files))
+        raise Error, failures.join("\n") unless failures.empty?
+
+        true
+      end
+
+      def git_tracked_files(root)
+        output = Dir.chdir(root) { `git ls-files` }
+        raise Error, "git ls-files failed" unless $CHILD_STATUS.success?
+
+        output.lines.map(&:strip)
+      end
+
+      def blocked_vscode_paths(tracked_files)
+        tracked_files
+          .grep(%r{\Aconfigs/vsc/(?!extensions\.yml\z|keybindings\.json\z|policy\.yml\z|settings\.json\z|tasks\.json\z|snippets/)})
+          .map { |path| "unexpected tracked VS Code config surface: #{path}" }
+      end
+
+      def sensitive_generated_paths(tracked_files)
+        tracked_files
+          .grep(%r{(^|/)(globalStorage|workspaceStorage|History|CachedData|logs|state\.vscdb|storage\.json|machineid|argv\.json)(/|$)})
+          .map { |path| "sensitive generated path is tracked: #{path}" }
+      end
+
+      def secret_pattern_failures(root, tracked_files)
+        tracked_files.filter_map do |path|
+          full_path = File.join(root, path)
+          next unless File.file?(full_path)
+
+          text = File.binread(full_path)
+          next if text.include?("\x00")
+          next unless SECRET_PATTERNS.any? { |pattern| text.match?(pattern) }
+
+          "possible committed secret pattern in #{path}"
+        end
+      end
+    end
+
+    class CLI
+      attr_reader :argv, :out, :err
+
+      def initialize(argv:, out: $stdout, err: $stderr)
+        @argv = argv.dup
+        @out = out
+        @err = err
+      end
+
+      def run
+        command = argv.shift
+        case command
+        when "jsonc"
+          require_args!(1)
+          argv.each { |path| JSONC.validate_file(path) }
+        when "yaml"
+          require_args!(1)
+          argv.each { |path| YAMLCheck.validate_file(path) }
+        when "bundler-supply-chain"
+          require_args!(1)
+          BundlerSupplyChain.validate(argv.fetch(0))
+        when "ci-workflow-action-pins"
+          require_args!(1)
+          CIWorkflowActionPins.validate(argv.fetch(0))
+        when "vscode-fixture-plan"
+          require_args!(1)
+          VSCodeFixturePlan.validate(argv.fetch(0))
+        when "public-safety"
+          require_args!(1)
+          PublicSafety.validate(argv.fetch(0))
+        when "--help", "-h"
+          out.puts usage
+        else
+          err.puts usage
+          return 2
+        end
+        0
+      rescue Error => e
+        err.puts e.message
+        1
+      end
+
+      private
+
+      def require_args!(count)
+        return if argv.length >= count
+
+        raise Error, "missing argument\n#{usage}"
+      end
+
+      def usage
+        <<~USAGE.chomp
+          Usage: script/test-check <command> [args]
+
+          Commands:
+            jsonc <path>...
+            yaml <path>...
+            bundler-supply-chain <repo-root>
+            ci-workflow-action-pins <repo-root>
+            vscode-fixture-plan <plan-json>
+            public-safety <repo-root>
+        USAGE
+      end
+    end
+  end
+end

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -9,7 +9,7 @@ source "$DIR/script/env" "$@"
 
 mkdir -p "$DIR/vendor/cache" "$DIR/vendor/gems"
 
-actual_ruby_version="$(ruby -e 'print RUBY_VERSION')"
+actual_ruby_version="$(ruby -v | awk '{print $2}')"
 if [ "$actual_ruby_version" != "$DOTFILES_RUBY_VERSION" ]; then
   echo "Expected Ruby $DOTFILES_RUBY_VERSION but found $actual_ruby_version." >&2
   echo "Install/select the pinned Ruby with rbenv, then rerun script/bootstrap." >&2

--- a/script/test
+++ b/script/test
@@ -21,161 +21,21 @@ require_command() {
 validate_jsonc() {
     local file_path=$1
 
-    ruby -rjson - "$file_path" <<'RUBY'
-path = ARGV.fetch(0)
-text = File.read(path)
-out = +""
-in_string = false
-escape = false
-chars = text.each_char.to_a
-i = 0
-
-while i < chars.length
-  char = chars[i]
-
-  if in_string
-    out << char
-    if escape
-      escape = false
-    elsif char == "\\"
-      escape = true
-    elsif char == '"'
-      in_string = false
-    end
-  elsif char == '"'
-    in_string = true
-    out << char
-  elsif char == "/" && chars[i + 1] == "/"
-    i += 2
-    i += 1 while i < chars.length && chars[i] != "\n"
-    out << "\n" if i < chars.length
-  elsif char == "/" && chars[i + 1] == "*"
-    i += 2
-    closed = false
-    while i < chars.length
-      if chars[i] == "*" && chars[i + 1] == "/"
-        i += 1
-        closed = true
-        break
-      end
-      out << "\n" if chars[i] == "\n"
-      i += 1
-    end
-    raise "unterminated block comment in #{path}" unless closed
-  else
-    out << char
-  end
-
-  i += 1
-end
-
-JSON.parse(out.gsub(/,\s*([}\]])/, '\1'))
-RUBY
+    "$ROOT/script/test-check" jsonc "$file_path"
 }
 
 validate_yaml() {
     local file_path=$1
 
-    ruby -ryaml - "$file_path" <<'RUBY'
-path = ARGV.fetch(0)
-text = File.read(path)
-YAML.safe_load(text, permitted_classes: [], permitted_symbols: [], aliases: false)
-RUBY
+    "$ROOT/script/test-check" yaml "$file_path"
 }
 
 validate_bundler_supply_chain() {
-    ruby -rbundler -ryaml - "$ROOT" <<'RUBY'
-root = ARGV.fetch(0)
-failures = []
-
-config_path = File.join(root, ".bundle/config")
-config = YAML.safe_load(File.read(config_path), permitted_classes: [], permitted_symbols: [], aliases: false)
-unless config.fetch("BUNDLE_FROZEN", nil) == "true"
-  failures << ".bundle/config must set BUNDLE_FROZEN: \"true\""
-end
-
-lock_path = File.join(root, "Gemfile.lock")
-lock_text = File.read(lock_path)
-unless lock_text.match?(/\ACHECKSUMS\n|\nCHECKSUMS\n/)
-  failures << "Gemfile.lock is missing CHECKSUMS"
-end
-
-checksum_entries = {}
-in_checksums = false
-lock_text.each_line do |line|
-  stripped = line.chomp
-  if stripped == "CHECKSUMS"
-    in_checksums = true
-    next
-  end
-  next unless in_checksums
-  break if stripped.match?(/\A[A-Z][A-Z ]*\z/)
-  next if stripped.empty?
-
-  match = stripped.match(/\A  (?<name>.+) \((?<version>[^)]+)\) sha256=(?<sha>[0-9a-f]{64})\z/)
-  if match
-    checksum_entries[[match[:name], match[:version]]] = match[:sha]
-  else
-    failures << "invalid Gemfile.lock checksum line: #{stripped}"
-  end
-end
-
-specs = Bundler::LockfileParser.new(lock_text).specs
-specs.each do |spec|
-  platform = spec.platform.to_s
-  checksum_version = platform == "ruby" ? spec.version.to_s : "#{spec.version}-#{platform}"
-  next if checksum_entries.key?([spec.name, checksum_version])
-
-  failures << "missing checksum for #{spec.name} (#{checksum_version})"
-end
-
-cache_dir = File.join(root, "vendor/cache")
-expected_cache = specs.map { |spec| "#{spec.full_name}.gem" }.sort
-actual_cache = Dir.exist?(cache_dir) ? Dir.children(cache_dir).grep(/\.gem\z/).sort : []
-missing_cache = expected_cache - actual_cache
-extra_cache = actual_cache - expected_cache
-
-missing_cache.each { |gem| failures << "missing cached gem: vendor/cache/#{gem}" }
-extra_cache.each { |gem| failures << "extra cached gem: vendor/cache/#{gem}" }
-
-unless failures.empty?
-  warn failures.join("\n")
-  exit 1
-end
-RUBY
+    "$ROOT/script/test-check" bundler-supply-chain "$ROOT"
 }
 
 validate_ci_workflow_action_pins() {
-    ruby - "$ROOT" <<'RUBY'
-root = ARGV.fetch(0)
-failures = []
-workflow_paths = Dir[File.join(root, ".github/workflows/*.{yml,yaml}")].sort
-
-workflow_paths.each do |path|
-  File.readlines(path).each_with_index do |line, index|
-    match = line.match(/\buses:\s*['"]?(?<uses>[^'"\s#]+)['"]?/)
-    next unless match
-
-    value = match[:uses]
-    next if value.start_with?("./")
-
-    valid = if value.start_with?("docker://")
-      value.match?(/@sha256:[0-9a-f]{64}\z/i)
-    else
-      value.match?(/@[0-9a-f]{40}\z/i)
-    end
-    next if valid
-
-    relative = path.delete_prefix("#{root}/")
-    failures << "#{relative}:#{index + 1} action is not SHA-pinned: #{value}"
-  end
-end
-
-unless failures.empty?
-  warn failures.join("\n")
-  exit 1
-end
-RUBY
+    "$ROOT/script/test-check" ci-workflow-action-pins "$ROOT"
 }
 
 validate_alias_metadata() {
@@ -220,113 +80,11 @@ validate_vscode_fixture_plan() {
     )"
     rm -rf "$fixture_user_dir"
 
-    ruby -rjson - "$fixture_plan" <<'RUBY'
-plan = JSON.parse(ARGV.fetch(0)).fetch("actions")
-
-def assert(message)
-  raise message unless yield
-end
-
-def action_for(plan, type, action, id: nil, key: nil)
-  plan.find do |entry|
-    entry["type"] == type &&
-      entry["action"] == action &&
-      (id.nil? || entry["id"] == id) &&
-      (key.nil? || entry["key"] == key)
-  end
-end
-
-assert("fixture should update non-auto-update drift") do
-  action_for(plan, "extension", "update", id: "donjayamanne.githistory")
-end
-
-assert("fixture should install missing baseline extension") do
-  action_for(plan, "extension", "install", id: "hashicorp.terraform")
-end
-
-assert("fixture should keep auto-updated ChatGPT") do
-  action_for(plan, "extension", "keep_auto_update", id: "openai.chatgpt")
-end
-
-assert("fixture should keep auto-updated Copilot Chat") do
-  action_for(plan, "extension", "keep_auto_update", id: "github.copilot-chat")
-end
-
-assert("fixture should prune untracked extension") do
-  action_for(plan, "extension", "prune", id: "untracked.publisher")
-end
-
-allowlist = action_for(plan, "storage", "configure", key: "extensions.autoUpdate")
-assert("fixture should configure selected auto-update allowlist") do
-  allowlist && allowlist.fetch("desired") == ["github.copilot-chat", "github.vscode-github-actions", "openai.chatgpt"]
-end
-
-denylist = action_for(plan, "storage", "configure", key: "extensions.donotAutoUpdate")
-assert("fixture should deny auto-update for tracked non-allowlisted extensions") do
-  denylist &&
-    denylist.fetch("desired").include?("donjayamanne.githistory") &&
-    !denylist.fetch("desired").include?("openai.chatgpt") &&
-    !denylist.fetch("desired").include?("github.copilot-chat") &&
-    !denylist.fetch("desired").include?("github.vscode-github-actions")
-end
-
-allowed = action_for(plan, "setting", "keep", key: "extensions.allowed") ||
-  action_for(plan, "setting", "write", key: "extensions.allowed")
-assert("fixture should pin non-auto-update extensions in extensions.allowed") do
-  allowed && allowed.fetch("desired").fetch("donjayamanne.githistory") == ["0.6.20"]
-end
-
-assert("fixture should allow only stable auto-update exceptions in extensions.allowed") do
-  allowed &&
-    allowed.fetch("desired").fetch("openai.chatgpt") == "stable" &&
-    allowed.fetch("desired").fetch("github.copilot-chat") == "stable" &&
-    allowed.fetch("desired").fetch("github.vscode-github-actions") == "stable"
-end
-RUBY
+    "$ROOT/script/test-check" vscode-fixture-plan "$fixture_plan"
 }
 
 validate_public_safety() {
-    ruby - "$ROOT" <<'RUBY'
-root = ARGV.fetch(0)
-Dir.chdir(root) do
-  tracked_files = `git ls-files`.lines.map(&:strip)
-  blocked_paths = tracked_files.grep(%r{\Aconfigs/vsc/(?!extensions\.yml\z|keybindings\.json\z|policy\.yml\z|settings\.json\z|tasks\.json\z|snippets/)})
-  sensitive_paths = tracked_files.grep(%r{(^|/)(globalStorage|workspaceStorage|History|CachedData|logs|state\.vscdb|storage\.json|machineid|argv\.json)(/|$)})
-  failures = []
-  failures.concat(blocked_paths.map { |path| "unexpected tracked VS Code config surface: #{path}" })
-  failures.concat(sensitive_paths.map { |path| "sensitive generated path is tracked: #{path}" })
-
-  secret_patterns = [
-    /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
-    /AKIA[0-9A-Z]{16}/,
-    /gh[pousr]_[A-Za-z0-9_]{36,}/,
-    /xox[baprs]-[A-Za-z0-9-]{20,}/,
-    /sk-[A-Za-z0-9]{32,}/,
-    /(?:api[_-]?key|access[_-]?token|client[_-]?secret|refresh[_-]?token)\s*[:=]\s*["']?[A-Za-z0-9_\.\/+=-]{20,}/i
-  ]
-  skip_secret_scan = %w[script/test]
-
-  tracked_files.each do |path|
-    next if skip_secret_scan.include?(path)
-    next unless File.file?(path)
-
-    text = File.binread(path)
-    next if text.include?("\x00")
-
-    secret_patterns.each do |pattern|
-      next unless text.match?(pattern)
-
-      failures << "possible committed secret pattern in #{path}"
-      break
-    end
-  end
-
-  unless failures.empty?
-    warn failures.join("\n")
-    exit 1
-  end
-end
-RUBY
+    "$ROOT/script/test-check" public-safety "$ROOT"
 }
 
 require_command bash
@@ -342,6 +100,7 @@ ruby -c "$ROOT/lib/dotfiles/installer.rb" >/dev/null
 ruby -c "$ROOT/lib/dotfiles/restorer.rb" >/dev/null
 ruby -c "$ROOT/lib/dotfiles/doctor.rb" >/dev/null
 ruby -c "$ROOT/lib/dotfiles/vendor.rb" >/dev/null
+ruby -c "$ROOT/lib/dotfiles/test_checks.rb" >/dev/null
 ruby -c "$ROOT/lib/dotfiles/vsc_extension_wrapper.rb" >/dev/null
 ruby -c "$ROOT/script/manifest" >/dev/null
 ruby -c "$ROOT/script/vscode" >/dev/null
@@ -349,6 +108,7 @@ ruby -c "$ROOT/script/install" >/dev/null
 ruby -c "$ROOT/script/restore" >/dev/null
 ruby -c "$ROOT/script/doctor" >/dev/null
 ruby -c "$ROOT/script/vendor" >/dev/null
+ruby -c "$ROOT/script/test-check" >/dev/null
 ruby -c "$ROOT/script/vsc-extension-bulk-install" >/dev/null
 "$ROOT/script/vscode" validate >/dev/null
 "$ROOT/script/vscode" plan >/dev/null

--- a/script/test-check
+++ b/script/test-check
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/dotfiles/test_checks"
+
+exit Dotfiles::TestChecks::CLI.new(argv: ARGV).run

--- a/spec/lib/test_checks_spec.rb
+++ b/spec/lib/test_checks_spec.rb
@@ -1,0 +1,328 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../lib/dotfiles/test_checks"
+
+RSpec.describe Dotfiles::TestChecks do
+  def write_file(root, relative_path, content)
+    path = File.join(root, relative_path)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+    path
+  end
+
+  def minimal_lock(checksums: true, checksum_line: "  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962")
+    <<~LOCK
+      GEM
+        remote: https://rubygems.org/
+        specs:
+          diff-lcs (1.6.2)
+
+      PLATFORMS
+        ruby
+
+      DEPENDENCIES
+        diff-lcs
+      #{checksums ? "\nCHECKSUMS\n#{checksum_line}\n" : ""}
+      BUNDLED WITH
+        4.0.6
+    LOCK
+  end
+
+  describe Dotfiles::TestChecks::JSONC do
+    it "validates JSON with line comments, block comments, trailing commas, and strings" do
+      path = write_file(
+        Dir.mktmpdir,
+        "settings.json",
+        <<~JSON
+          {
+            // comment
+            "url": "https://example.com/not-comment",
+            "escaped": "quote: \\"",
+            /*
+              block comment
+            */
+            "items": [
+              "a",
+            ],
+          }
+        JSON
+      )
+
+      expect(described_class.validate_file(path)).to eq(true)
+      expect(JSON.parse(described_class.strip(File.read(path)))).to eq(
+        "url" => "https://example.com/not-comment",
+        "escaped" => "quote: \"",
+        "items" => ["a"]
+      )
+    end
+
+    it "rejects invalid JSON after stripping comments" do
+      path = write_file(Dir.mktmpdir, "bad.json", "{")
+
+      expect { described_class.validate_file(path) }
+        .to raise_error(Dotfiles::TestChecks::Error, /invalid JSON\/JSONC/)
+    end
+
+    it "rejects missing JSON files" do
+      expect { described_class.validate_file("/missing/nope.json") }
+        .to raise_error(Dotfiles::TestChecks::Error, /file not found/)
+    end
+
+    it "rejects unterminated block comments" do
+      expect { described_class.strip("{ /* nope") }
+        .to raise_error(Dotfiles::TestChecks::Error, /unterminated block comment/)
+    end
+  end
+
+  describe Dotfiles::TestChecks::YAMLCheck do
+    it "validates YAML files" do
+      path = write_file(Dir.mktmpdir, "config.yml", "---\nkey: value\n")
+
+      expect(described_class.validate_file(path)).to eq(true)
+    end
+
+    it "rejects invalid YAML" do
+      path = write_file(Dir.mktmpdir, "bad.yml", "key: [")
+
+      expect { described_class.validate_file(path) }
+        .to raise_error(Dotfiles::TestChecks::Error, /invalid YAML/)
+    end
+
+    it "rejects missing YAML files" do
+      expect { described_class.validate_file("/missing/nope.yml") }
+        .to raise_error(Dotfiles::TestChecks::Error, /file not found/)
+    end
+  end
+
+  describe Dotfiles::TestChecks::BundlerSupplyChain do
+    def write_bundler_project(root, lock_text: minimal_lock, config: { "BUNDLE_FROZEN" => "true" }, cache_files: ["diff-lcs-1.6.2.gem"])
+      write_file(root, ".bundle/config", YAML.dump(config))
+      write_file(root, "Gemfile.lock", lock_text)
+      cache_files.each { |name| write_file(root, "vendor/cache/#{name}", "gem") }
+    end
+
+    it "accepts frozen config, checksums, and exact cached gems" do
+      root = Dir.mktmpdir
+      write_bundler_project(root)
+
+      expect(described_class.validate(root)).to eq(true)
+    end
+
+    it "reports unfrozen config, missing checksum section, and missing cached gems" do
+      root = Dir.mktmpdir
+      write_bundler_project(root, lock_text: minimal_lock(checksums: false), config: {}, cache_files: [])
+
+      expect { described_class.validate(root) }
+        .to raise_error(Dotfiles::TestChecks::Error) { |error|
+          expect(error.message).to include(
+            ".bundle/config must set BUNDLE_FROZEN",
+            "Gemfile.lock is missing CHECKSUMS",
+            "missing checksum for diff-lcs (1.6.2)",
+            "missing cached gem: vendor/cache/diff-lcs-1.6.2.gem"
+          )
+        }
+    end
+
+    it "reports malformed checksum entries and extra cached gems" do
+      root = Dir.mktmpdir
+      write_bundler_project(root, lock_text: minimal_lock(checksum_line: "  nope"), cache_files: ["diff-lcs-1.6.2.gem", "extra-1.0.0.gem"])
+
+      expect { described_class.validate(root) }
+        .to raise_error(Dotfiles::TestChecks::Error) { |error|
+          expect(error.message).to include(
+            "invalid Gemfile.lock checksum line:   nope",
+            "missing checksum for diff-lcs (1.6.2)",
+            "extra cached gem: vendor/cache/extra-1.0.0.gem"
+          )
+        }
+    end
+
+    it "reports missing Bundler files" do
+      expect { described_class.validate(Dir.mktmpdir) }
+        .to raise_error(Dotfiles::TestChecks::Error, /No such file or directory/)
+    end
+  end
+
+  describe Dotfiles::TestChecks::CIWorkflowActionPins do
+    it "accepts SHA-pinned actions, Docker digests, and local actions" do
+      root = Dir.mktmpdir
+      write_file(root, ".github/workflows/test.yml", <<~YAML)
+        jobs:
+          test:
+            steps:
+              - uses: actions/checkout@#{'a' * 40}
+              - uses: docker://alpine@sha256:#{'b' * 64}
+              - uses: ./local-action
+      YAML
+
+      expect(described_class.validate(root)).to eq(true)
+    end
+
+    it "rejects unpinned workflow actions" do
+      root = Dir.mktmpdir
+      write_file(root, ".github/workflows/test.yml", <<~YAML)
+        jobs:
+          test:
+            steps:
+              - uses: actions/checkout@v6
+              - uses: docker://alpine:latest
+      YAML
+
+      expect { described_class.validate(root) }
+        .to raise_error(Dotfiles::TestChecks::Error) { |error|
+          expect(error.message).to include(
+            ".github/workflows/test.yml:4 action is not SHA-pinned: actions/checkout@v6",
+            ".github/workflows/test.yml:5 action is not SHA-pinned: docker://alpine:latest"
+          )
+        }
+    end
+  end
+
+  describe Dotfiles::TestChecks::VSCodeFixturePlan do
+    def action(type, action, extra = {})
+      { "type" => type, "action" => action }.merge(extra)
+    end
+
+    def valid_plan_json
+      JSON.dump(
+        "actions" => [
+          action("extension", "update", "id" => "donjayamanne.githistory"),
+          action("extension", "install", "id" => "hashicorp.terraform"),
+          action("extension", "keep_auto_update", "id" => "openai.chatgpt"),
+          action("extension", "keep_auto_update", "id" => "github.copilot-chat"),
+          action("extension", "prune", "id" => "untracked.publisher"),
+          action("storage", "configure", "key" => "extensions.autoUpdate", "desired" => ["github.copilot-chat", "github.vscode-github-actions", "openai.chatgpt"]),
+          action("storage", "configure", "key" => "extensions.donotAutoUpdate", "desired" => ["donjayamanne.githistory"]),
+          action("setting", "write", "key" => "extensions.allowed", "desired" => {
+            "donjayamanne.githistory" => ["0.6.20"],
+            "openai.chatgpt" => "stable",
+            "github.copilot-chat" => "stable",
+            "github.vscode-github-actions" => "stable"
+          })
+        ]
+      )
+    end
+
+    it "accepts the expected VS Code fixture plan" do
+      expect(described_class.validate(valid_plan_json)).to eq(true)
+    end
+
+    it "rejects invalid JSON" do
+      expect { described_class.validate("{") }
+        .to raise_error(Dotfiles::TestChecks::Error, /fixture plan is invalid JSON/)
+    end
+
+    it "rejects JSON without actions" do
+      expect { described_class.validate("{}") }
+        .to raise_error(Dotfiles::TestChecks::Error, /fixture plan is missing actions/)
+    end
+
+    it "reports the first failed fixture assertion" do
+      bad_plan = JSON.parse(valid_plan_json)
+      bad_plan.fetch("actions").reject! { |entry| entry["id"] == "hashicorp.terraform" }
+
+      expect { described_class.validate(JSON.dump(bad_plan)) }
+        .to raise_error(Dotfiles::TestChecks::Error, /fixture should install missing baseline extension/)
+    end
+  end
+
+  describe Dotfiles::TestChecks::PublicSafety do
+    it "accepts safe tracked files" do
+      root = Dir.mktmpdir
+      write_file(root, "README.md", "hello")
+
+      expect(described_class.validate(root, tracked_files: ["README.md"])).to eq(true)
+    end
+
+    it "reports unexpected VS Code config and generated state paths" do
+      root = Dir.mktmpdir
+
+      expect {
+        described_class.validate(root, tracked_files: [
+          "configs/vsc/mcp.json",
+          "configs/vsc/snippets/example.json",
+          "Library/Application Support/Code/User/globalStorage/state.vscdb"
+        ])
+      }.to raise_error(Dotfiles::TestChecks::Error) { |error|
+        expect(error.message).to include(
+          "unexpected tracked VS Code config surface: configs/vsc/mcp.json",
+          "sensitive generated path is tracked: Library/Application Support/Code/User/globalStorage/state.vscdb"
+        )
+        expect(error.message).not_to include("configs/vsc/snippets/example.json")
+      }
+    end
+
+    it "reports secret-like file contents and ignores binary files" do
+      root = Dir.mktmpdir
+      write_file(root, "secret.txt", "token=#{'ghp_' + ('A' * 36)}")
+      write_file(root, "binary.bin", "abc\x00#{'sk-' + ('B' * 32)}")
+
+      expect { described_class.validate(root, tracked_files: ["secret.txt", "binary.bin"]) }
+        .to raise_error(Dotfiles::TestChecks::Error, /possible committed secret pattern in secret.txt/)
+    end
+
+    it "uses git ls-files when tracked files are not provided" do
+      root = Dir.mktmpdir
+      write_file(root, "tracked.txt", "safe")
+      Dir.chdir(root) do
+        system("git", "init", "--quiet")
+        system("git", "add", "tracked.txt")
+      end
+
+      expect(described_class.validate(root)).to eq(true)
+    end
+  end
+
+  describe Dotfiles::TestChecks::CLI do
+    def run_cli(args)
+      out = StringIO.new
+      err = StringIO.new
+      status = described_class.new(argv: args, out: out, err: err).run
+      [status, out.string, err.string]
+    end
+
+    it "runs file validation commands" do
+      root = Dir.mktmpdir
+      json = write_file(root, "ok.json", "{// comment\n\"ok\": true}\n")
+      yaml = write_file(root, "ok.yml", "---\nok: true\n")
+
+      expect(run_cli(["jsonc", json]).first).to eq(0)
+      expect(run_cli(["yaml", yaml]).first).to eq(0)
+    end
+
+    it "runs repo validation commands" do
+      expect(Dotfiles::TestChecks::BundlerSupplyChain).to receive(:validate).with("/repo")
+      expect(Dotfiles::TestChecks::CIWorkflowActionPins).to receive(:validate).with("/repo")
+      expect(Dotfiles::TestChecks::VSCodeFixturePlan).to receive(:validate).with("{}")
+      expect(Dotfiles::TestChecks::PublicSafety).to receive(:validate).with("/repo")
+
+      expect(run_cli(["bundler-supply-chain", "/repo"]).first).to eq(0)
+      expect(run_cli(["ci-workflow-action-pins", "/repo"]).first).to eq(0)
+      expect(run_cli(["vscode-fixture-plan", "{}"]).first).to eq(0)
+      expect(run_cli(["public-safety", "/repo"]).first).to eq(0)
+    end
+
+    it "prints usage for help and unknown commands" do
+      help_status, help_out, help_err = run_cli(["--help"])
+      unknown_status, unknown_out, unknown_err = run_cli(["wat"])
+
+      expect(help_status).to eq(0)
+      expect(help_out).to include("Usage: script/test-check")
+      expect(help_err).to eq("")
+      expect(unknown_status).to eq(2)
+      expect(unknown_out).to eq("")
+      expect(unknown_err).to include("Usage: script/test-check")
+    end
+
+    it "reports missing arguments and validation failures" do
+      missing_status, _out, missing_err = run_cli(["jsonc"])
+      invalid_status, _invalid_out, invalid_err = run_cli(["jsonc", "/missing/nope.json"])
+
+      expect(missing_status).to eq(1)
+      expect(missing_err).to include("missing argument", "Usage: script/test-check")
+      expect(invalid_status).to eq(1)
+      expect(invalid_err).to include("file not found")
+    end
+  end
+end

--- a/spec/scripts/ruby_entrypoints_spec.rb
+++ b/spec/scripts/ruby_entrypoints_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 require_relative "../../lib/dotfiles/doctor"
 require_relative "../../lib/dotfiles/installer"
 require_relative "../../lib/dotfiles/restorer"
+require_relative "../../lib/dotfiles/test_checks"
 require_relative "../../lib/dotfiles/vendor"
 require_relative "../../lib/dotfiles/vsc_extension_wrapper"
 
@@ -42,6 +43,15 @@ RSpec.describe "Ruby script entrypoints" do
     result = run_script(File.join(ROOT, "script/vendor"), ["--dry-run"])
 
     expect(result).to include(status: 4)
+  end
+
+  it "runs script/test-check through Dotfiles::TestChecks::CLI" do
+    runner = instance_double(Dotfiles::TestChecks::CLI, run: 5)
+    expect(Dotfiles::TestChecks::CLI).to receive(:new).with(argv: ["--help"]).and_return(runner)
+
+    result = run_script(File.join(ROOT, "script/test-check"), ["--help"])
+
+    expect(result).to include(status: 5)
   end
 
   it "runs script/vsc-extension-bulk-install through the wrapper" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ COVERAGE_TARGETS = (
     script/install
     script/manifest
     script/restore
+    script/test-check
     script/vendor
     script/vsc-extension-bulk-install
     script/vscode


### PR DESCRIPTION
## Summary

Moves the Ruby validation logic out of `script/test` and into `lib/dotfiles/test_checks.rb` behind the new `script/test-check` entrypoint. This keeps Bash as orchestration, makes the validation logic directly RSpec-testable, and updates `AGENTS.md` to avoid embedded Ruby in Bash going forward.