### PR TITLE
Ensure RubyGems cooldown matches ruby platform metadata

### DIFF
--- a/lib/dotfiles/vendor.rb
+++ b/lib/dotfiles/vendor.rb
@@ -141,8 +141,11 @@ module Dotfiles
       metadata = @client.versions(locked_gem.name).find do |version|
         version_number = version.fetch("number", "").to_s
         platform = version.fetch("platform", "ruby").to_s
-        locked_gem.version == version_number ||
+        if locked_gem.version == version_number
+          platform == "ruby"
+        else
           locked_gem.version == "#{version_number}-#{platform}"
+        end
       end
       return metadata if metadata
 

--- a/spec/lib/vendor_spec.rb
+++ b/spec/lib/vendor_spec.rb
@@ -187,6 +187,23 @@ RSpec.describe Dotfiles::Vendor do
     )
   end
 
+  it "matches ruby lockfile entries to ruby platform metadata" do
+    lockfile_path = write_lockfile(TOO_NEW_LOCKFILE)
+    metadata_client = FakeRubyGemsClient.new(
+      "fresh-gem" => [
+        { "number" => "9.0.0", "platform" => "x86_64-linux", "created_at" => "2025-01-01T00:00:00Z" },
+        { "number" => "9.0.0", "platform" => "ruby", "created_at" => "2026-05-01T00:00:00Z" }
+      ]
+    )
+    vendor = build_vendor(runner: ->(*) { true }, metadata_client: metadata_client, lockfile_path: lockfile_path)
+
+    expect(vendor.run).to eq(1)
+    expect(vendor.err.string).to include(
+      "RubyGems cooldown rejected versions newer than 45 days",
+      "fresh-gem 9.0.0 was published 2026-05-01T00:00:00Z"
+    )
+  end
+
   it "returns an error when Gemfile.lock is missing" do
     vendor = build_vendor(lockfile_path: File.join(tmpdir, "missing.lock"))
 


### PR DESCRIPTION
### Motivation
- The RubyGems cooldown check could pick an older non-`ruby` platform metadata record for a plain lockfile version (e.g. `1.0.0`), allowing a freshly published `ruby` platform gem to bypass the cooldown.
- The fix narrows metadata matching so plain version entries only match metadata with `platform == "ruby"`, preserving the intended supply-chain cooldown protection.

### Description
- Change `Dotfiles::Vendor#metadata_for` so that when a locked entry equals the bare `version` string it only returns metadata whose `platform` is `"ruby"`, while leaving explicit `version-platform` matching unchanged in behavior.
- Add a regression spec `spec/lib/vendor_spec.rb` that creates a metadata ordering with an older non-`ruby` entry followed by a newer `ruby` entry and asserts the cooldown rejects the newer `ruby` record.
- Keep error behavior intact by raising when no matching metadata is found and preserve existing cooldown messaging and restore behavior.

### Testing
- Ran `git diff --check`, which returned clean results.
- Ran `script/manifest validate`, which succeeded (`Manifest OK`).
- Attempted `bundle exec rspec spec/lib/vendor_spec.rb`, but the `rspec` executable was not available in this execution environment so the spec run could not be completed here (test added to exercise the regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fdbbca1f8832fafd26d8fc50dd56a)