### PR TITLE
Prevent env-injection in set_secret by avoiding variable-name collision

### DIFF
--- a/script/test
+++ b/script/test
@@ -92,29 +92,47 @@ validate_public_safety() {
 }
 
 validate_set_secret_collision_guard() {
-    local candidate
-
-    for candidate in var_name target_var secret_value; do
-        CANDIDATE="$candidate" bash <<'BASH'
+    bash <<'BASH'
 set -euo pipefail
 
 source "shell/functions/secrets.bash"
-unset INJECTED
-unset -v "$CANDIDATE"
 
-set_secret "$CANDIDATE" <<<"INJECTED=1" >/dev/null
+for candidate in var_name target_var secret_value "_dotfiles_set_secret_value_$$"; do
+    unset INJECTED
+    unset -v "$candidate"
 
-if [ "${INJECTED-unset}" != "unset" ]; then
-    echo "set_secret exported injected assignment for $CANDIDATE" >&2
-    exit 1
-fi
+    set_secret "$candidate" <<<"INJECTED=1" >/dev/null
 
-if [ "${!CANDIDATE}" != "INJECTED=1" ]; then
-    echo "set_secret did not assign $CANDIDATE" >&2
-    exit 1
-fi
+    if [ "${INJECTED-unset}" != "unset" ]; then
+        echo "set_secret exported injected assignment for $candidate" >&2
+        exit 1
+    fi
+
+    if [ "${!candidate}" != "INJECTED=1" ]; then
+        echo "set_secret did not assign $candidate" >&2
+        exit 1
+    fi
+
+    unset INJECTED
+    printf -v "$candidate" '%s' old
+    export "$candidate"
+
+    if set_secret "$candidate" < <(printf partial) >/dev/null 2>/dev/null; then
+        echo "set_secret succeeded on partial input for $candidate" >&2
+        exit 1
+    fi
+
+    if [ "${!candidate}" != "old" ]; then
+        echo "set_secret clobbered $candidate after failed read" >&2
+        exit 1
+    fi
+
+    if [ "${INJECTED-unset}" != "unset" ]; then
+        echo "set_secret exported injected assignment after failed read for $candidate" >&2
+        exit 1
+    fi
+done
 BASH
-    done
 }
 
 require_command bash

--- a/script/test
+++ b/script/test
@@ -91,6 +91,32 @@ validate_public_safety() {
     "$ROOT/script/test-check" public-safety "$ROOT"
 }
 
+validate_set_secret_collision_guard() {
+    local candidate
+
+    for candidate in var_name target_var secret_value; do
+        CANDIDATE="$candidate" bash <<'BASH'
+set -euo pipefail
+
+source "shell/functions/secrets.bash"
+unset INJECTED
+unset -v "$CANDIDATE"
+
+set_secret "$CANDIDATE" <<<"INJECTED=1" >/dev/null
+
+if [ "${INJECTED-unset}" != "unset" ]; then
+    echo "set_secret exported injected assignment for $CANDIDATE" >&2
+    exit 1
+fi
+
+if [ "${!CANDIDATE}" != "INJECTED=1" ]; then
+    echo "set_secret did not assign $CANDIDATE" >&2
+    exit 1
+fi
+BASH
+    done
+}
+
 require_command bash
 require_command bundle
 require_command git
@@ -148,6 +174,8 @@ done < <(find local-bin -type f -print | sort)
 for shell_file in "${shell_files[@]}"; do
     bash -n "$shell_file"
 done
+
+validate_set_secret_collision_guard
 
 json_files=(
     "configs/karabiner/karabiner.json"

--- a/shell/functions/secrets.bash
+++ b/shell/functions/secrets.bash
@@ -1,24 +1,19 @@
 set_secret() {
-    local var_name="${1:-}"
-    local secret_value=""
-
     if [ "$#" -ne 1 ]; then
         echo "Usage: set_secret VAR_NAME" >&2
         return 2
     fi
 
-    if [[ ! "$var_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+    if [[ ! "$1" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
         echo "set_secret requires a valid shell variable name." >&2
         return 2
     fi
 
-    if ! read -rs -p "${var_name}=" secret_value; then
+    if ! read -rs -p "${1}=" "$1"; then
         echo >&2
         return 1
     fi
     echo
 
-    printf -v "$var_name" '%s' "$secret_value"
-    export "$var_name"
-    unset secret_value
+    export "$1"
 }

--- a/shell/functions/secrets.bash
+++ b/shell/functions/secrets.bash
@@ -9,11 +9,20 @@ set_secret() {
         return 2
     fi
 
-    if ! read -rs -p "${1}=" "$1"; then
+    set -- "$1" "_dotfiles_set_secret_value_$$"
+    while [ "$1" = "$2" ]; do
+        set -- "$1" "${2}_x"
+    done
+
+    local "$2"
+    if ! read -rs -p "${1}=" "$2"; then
         echo >&2
+        unset "$2"
         return 1
     fi
     echo
 
+    printf -v "$1" '%s' "${!2}"
+    unset "$2"
     export "$1"
 }


### PR DESCRIPTION
### Motivation
- Fix `set_secret` env-injection caused by function-local helper variables colliding with caller-selected variable names.
- Preserve existing exported secrets when a read fails after partial input.

### Description
- Validate the requested variable name directly from `$1`.
- Stage reads through a dynamically named local variable that cannot collide with the requested target name.
- Assign and export only after the read succeeds.
- Add regression coverage for helper-name collisions, the dynamic staging-name collision, and failed partial reads.