### PR TITLE
Install pinned Socket Firewall binary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,11 @@ The repo is public. Treat every committed byte as public-facing.
 - `local-bin/git-secretive-ssh-keygen`: Git SSH signing wrapper that runs
   `ssh-keygen` with Secretive's agent socket and refuses non-managed signing
   key files for signing operations.
+- `configs/sfw/sfw.yml`: Pinned Socket Firewall Free release metadata, including
+  version, asset URL, size, SHA256, and GitHub release digest.
+- `lib/dotfiles/sfw_binary.rb`: Verifies and installs the pinned Socket Firewall
+  binary into `~/.local/bin/sfw` without committing the binary to this public
+  repo.
 - `lib/dotfiles/vscode.rb`: VS Code manifest parser, planner, applier, and
   validation logic.
 - `dotfiles/`: Shell, Git, Ruby, profile, and alias metadata.
@@ -109,6 +114,10 @@ Managed files currently include:
 - Optionally `~/Library/Application Support/Code/User/mcp.json` when the ignored
   local source `configs/vsc/mcp.json` exists.
 
+Separately, `script/install` reconciles `~/.local/bin/sfw` as a verified pinned
+binary from `configs/sfw/sfw.yml` when missing or mismatched, unless explicitly
+skipped.
+
 `script/install` also generates `~/.config/git/secretive-program.gitconfig`
 with the current machine's absolute path to the Secretive signing wrapper,
 because Git does not expand `~` for `gpg.ssh.program`. This generated include
@@ -135,6 +144,13 @@ in dry-run mode.
 `script/install --skip-vscode-extensions` skips extension management while still
 installing manifest-managed files. Use it only when intentionally avoiding
 VS Code changes for that run.
+
+`script/install --skip-sfw-binary` skips Socket Firewall binary reconciliation.
+The normal install path should verify the pinned binary already present at
+`~/.local/bin/sfw` without network access. If the binary is missing or
+mismatched, it may fetch the pinned GitHub release metadata and asset, verify
+the committed SHA256 and release digest, and then install the binary. Do not
+commit the SFW release binary to this public repository.
 
 The installer writes state to `.dotfiles/state/install-*.tsv`, which is ignored
 by git. Do not commit install state.
@@ -357,6 +373,10 @@ This repo also installs PATH shims for the Socket Firewall Free-supported
 package managers `npm`, `yarn`, `pnpm`, `pip`, `uv`, and `cargo`. Those shims
 are intended to protect non-interactive commands from agents such as Codex when
 the protected shim directory is present in `PATH`.
+
+The shims should execute `DOTFILES_SFW_BIN`, which defaults to
+`~/.local/bin/sfw`, rather than resolving `sfw` through `PATH`. This avoids
+depending on a nodenv-scoped global npm install of SFW.
 
 Do not use bare `npx`, `uvx`, `pipx`, `poetry install`, `bun install`,
 `gem install`, `bundle install`, `go get`, `mvn`, `gradle`, or `dotnet restore`

--- a/configs/sfw/sfw.yml
+++ b/configs/sfw/sfw.yml
@@ -1,0 +1,12 @@
+---
+version: v1.10.0
+asset: sfw-free-macos-arm64
+url: https://github.com/SocketDev/sfw-free/releases/download/v1.10.0/sfw-free-macos-arm64
+sha256: fd75944bddc663bee2b19f15367706387113d9609fea4f51b02fc3b5dbdb9281
+size: 127527616
+github_digest: sha256:fd75944bddc663bee2b19f15367706387113d9609fea4f51b02fc3b5dbdb9281
+upstream_repo: SocketDev/sfw-free
+release_api_url: https://api.github.com/repos/SocketDev/sfw-free/releases/tags/v1.10.0
+license:
+  name: PolyForm Shield License 1.0.0
+  url: https://github.com/SocketDev/sfw-free#license

--- a/lib/dotfiles/installer.rb
+++ b/lib/dotfiles/installer.rb
@@ -3,6 +3,7 @@
 require "fileutils"
 require_relative "manifest"
 require_relative "runtime"
+require_relative "sfw_binary"
 require_relative "vscode"
 
 module Dotfiles
@@ -22,6 +23,7 @@ module Dotfiles
       err: $stderr,
       platform: RUBY_PLATFORM,
       manifest: nil,
+      sfw_binary: nil,
       vscode_manager: nil,
       state_dir: File.join(ROOT, ".dotfiles/state"),
       default_directories: DEFAULT_DIRECTORIES,
@@ -33,12 +35,14 @@ module Dotfiles
       @err = err
       @platform = platform
       @manifest = manifest
+      @sfw_binary = sfw_binary
       @vscode_manager = vscode_manager
       @state_dir = state_dir
       @default_directories = default_directories
       @color = color
       @dry_run = false
       @install_vscode_extensions = true
+      @install_sfw_binary = env_sfw_install_enabled?
       @dir_changes = 0
       @manifest_ok = 0
       @manifest_changes = 0
@@ -64,6 +68,8 @@ module Dotfiles
       section "📁 Managed files"
       install_manifest_entries
       print_manifest_summary
+      section "🛡️ Socket Firewall"
+      install_sfw_binary
       section "🔐 Git"
       install_git_secretive_program_include
       write_state_file unless dry_run?
@@ -101,6 +107,8 @@ module Dotfiles
           @dry_run = true
         when "--skip-vscode-extensions"
           @install_vscode_extensions = false
+        when "--skip-sfw-binary"
+          @install_sfw_binary = false
         when "--production"
           next
         when "--help", "-h"
@@ -116,10 +124,18 @@ module Dotfiles
 
     def usage
       <<~USAGE
-        Usage: script/install [--dry-run] [--skip-vscode-extensions]
+        Usage: script/install [--dry-run] [--skip-vscode-extensions] [--skip-sfw-binary]
 
-        Install managed dotfiles from install.yml and reconcile the VS Code extension manifest.
+        Install managed dotfiles, reconcile the Socket Firewall binary, and reconcile the VS Code extension manifest.
       USAGE
+    end
+
+    def env_sfw_install_enabled?
+      ENV.fetch("DOTFILES_SKIP_SFW_BINARY", "0") != "1"
+    end
+
+    def sfw_binary
+      @sfw_binary ||= SFWBinary.new(home: home, out: out, err: err)
     end
 
     def ensure_default_directories
@@ -259,6 +275,15 @@ module Dotfiles
         File.write(path, content)
         success "Git Secretive signing helper include: wrote #{path}"
       end
+    end
+
+    def install_sfw_binary
+      unless @install_sfw_binary
+        info "Socket Firewall binary: skipped"
+        return
+      end
+
+      sfw_binary.install(dry_run: dry_run?)
     end
 
     def git_secretive_program_include_content

--- a/lib/dotfiles/installer.rb
+++ b/lib/dotfiles/installer.rb
@@ -68,11 +68,11 @@ module Dotfiles
       section "📁 Managed files"
       install_manifest_entries
       print_manifest_summary
+      write_state_file unless dry_run?
       section "🛡️ Socket Firewall"
       install_sfw_binary
       section "🔐 Git"
       install_git_secretive_program_include
-      write_state_file unless dry_run?
 
       section "🧩 VS Code"
       reconcile_vscode

--- a/lib/dotfiles/sfw_binary.rb
+++ b/lib/dotfiles/sfw_binary.rb
@@ -211,10 +211,10 @@ module Dotfiles
       FileUtils.cp(source, tmp)
       FileUtils.chmod(0o755, tmp)
       raise Error, "installed SFW binary failed verification" unless matching?(tmp)
+      verify_signature!(tmp)
 
       backup_existing_target
       FileUtils.mv(tmp, target_path)
-      handle_quarantine(target_path)
       out.puts "Socket Firewall binary: installed #{target_path}"
     ensure
       FileUtils.rm_f(tmp) if tmp && File.exist?(tmp)
@@ -232,7 +232,7 @@ module Dotfiles
       end
 
       FileUtils.chmod(0o755, target_path)
-      handle_quarantine(target_path)
+      verify_signature!(target_path)
       out.puts "Socket Firewall binary: repaired executable mode on #{target_path}"
     end
 
@@ -244,22 +244,16 @@ module Dotfiles
       out.puts "Socket Firewall binary: backed up existing target to #{backup}"
     end
 
-    def handle_quarantine(path)
-      signing = signing_status(path)
-      case signing
-      when "valid"
-        out.puts "Socket Firewall binary: signed binary verified; leaving quarantine attributes unchanged"
-      when "unsigned"
-        @command_runner.call(["/usr/bin/xattr", "-d", "com.apple.quarantine", path])
-        out.puts "Socket Firewall binary: removed quarantine attribute for unsigned binary"
-      else
-        raise Error, "SFW binary signature verification failed"
-      end
+    def verify_signature!(path)
+      raise Error, "SFW binary signature verification failed" unless signing_status(path) == "valid"
+
+      out.puts "Socket Firewall binary: signed binary verified; leaving quarantine attributes unchanged"
     end
 
     def signing_status(path)
       result = @command_runner.call(["/usr/bin/codesign", "--verify", "--strict", "--verbose=2", path])
       return "valid" if result.success?
+      return "unavailable" if command_unavailable?(result, "/usr/bin/codesign")
 
       output = "#{result.stdout}\n#{result.stderr}"
       return "unsigned" if output.include?("code object is not signed") || output.include?("is not signed at all")
@@ -271,6 +265,8 @@ module Dotfiles
       return "missing" unless File.file?(path)
 
       result = @command_runner.call(["/usr/bin/xattr", "-p", "com.apple.quarantine", path])
+      return "unavailable" if command_unavailable?(result, "/usr/bin/xattr")
+
       result.success? ? "present" : "absent"
     end
 
@@ -278,6 +274,11 @@ module Dotfiles
       return "missing" unless File.file?(path)
 
       File.executable?(path) ? "ok" : "not-executable"
+    end
+
+    def command_unavailable?(result, command)
+      output = "#{result.stdout}\n#{result.stderr}"
+      output.include?("command not found: #{command}")
     end
 
     def fetch_release(url)
@@ -318,6 +319,8 @@ module Dotfiles
     def run_command(command)
       stdout, stderr, status = Open3.capture3(*command)
       CommandResult.new(success: status.success?, stdout: stdout, stderr: stderr)
+    rescue Errno::ENOENT
+      CommandResult.new(success: false, stderr: "command not found: #{command.first}")
     end
   end
 end

--- a/lib/dotfiles/sfw_binary.rb
+++ b/lib/dotfiles/sfw_binary.rb
@@ -1,0 +1,323 @@
+# frozen_string_literal: true
+
+require "digest"
+require "fileutils"
+require "json"
+require "net/http"
+require "open3"
+require "tmpdir"
+require "yaml"
+
+require_relative "manifest"
+require_relative "runtime"
+
+module Dotfiles
+  class SFWBinary
+    DEFAULT_CONFIG_PATH = File.join(ROOT, "configs/sfw/sfw.yml")
+    SHA256_PATTERN = /\A[0-9a-f]{64}\z/.freeze
+    DIGEST_PREFIX = "sha256:"
+
+    class CommandResult
+      attr_reader :stdout, :stderr
+
+      def initialize(success:, stdout: "", stderr: "")
+        @success = success
+        @stdout = stdout
+        @stderr = stderr
+      end
+
+      def success?
+        @success
+      end
+    end
+
+    attr_reader :config_path, :env, :home, :out, :err
+
+    def initialize(
+      config_path: DEFAULT_CONFIG_PATH,
+      env: ENV,
+      home: ENV.fetch("HOME"),
+      out: $stdout,
+      err: $stderr,
+      release_fetcher: nil,
+      downloader: nil,
+      command_runner: nil
+    )
+      @config_path = config_path
+      @env = env
+      @home = home
+      @out = out
+      @err = err
+      @release_fetcher = release_fetcher || method(:fetch_release)
+      @downloader = downloader || method(:download)
+      @command_runner = command_runner || method(:run_command)
+    end
+
+    def metadata
+      @metadata ||= load_metadata
+    end
+
+    def target_path
+      env.fetch("DOTFILES_SFW_BIN", File.join(home, ".local/bin/sfw"))
+    end
+
+    def expected_sha256
+      metadata.fetch("sha256")
+    end
+
+    def actual_sha256(path = target_path)
+      return nil unless File.file?(path)
+
+      Digest::SHA256.file(path).hexdigest
+    end
+
+    def matching?(path = target_path)
+      actual_sha256(path) == expected_sha256
+    end
+
+    def verify(path = target_path)
+      actual = actual_sha256(path)
+      out.puts "Socket Firewall binary verify"
+      out.puts "  path:     #{path}"
+      out.puts "  expected: #{expected_sha256}"
+      out.puts "  actual:   #{actual || "<missing>"}"
+      raise Error, "sfw binary is missing: #{path}" unless actual
+      raise Error, "sfw binary SHA256 mismatch: #{path}" unless actual == expected_sha256
+
+      out.puts "  status:   ok"
+      true
+    end
+
+    def status
+      actual = actual_sha256
+      signing = File.file?(target_path) ? signing_status(target_path) : "missing"
+      {
+        "path" => target_path,
+        "expected_sha256" => expected_sha256,
+        "actual_sha256" => actual || "<missing>",
+        "hash_status" => actual == expected_sha256 ? "ok" : "mismatch",
+        "executable_status" => executable_status(target_path),
+        "signing_status" => signing,
+        "quarantine_status" => quarantine_status(target_path)
+      }
+    end
+
+    def install(dry_run: false)
+      if matching?
+        repair_matching_target(dry_run: dry_run)
+        return true
+      end
+
+      if dry_run
+        out.puts "Socket Firewall binary: would install #{metadata.fetch("asset")} to #{target_path}"
+        return true
+      end
+
+      verify_release_metadata!
+      source = valid_seed_path || download_asset
+      install_source(source)
+      true
+    end
+
+    private
+
+    def load_metadata
+      data = YAML.safe_load(File.read(config_path), permitted_classes: [], permitted_symbols: [], aliases: false)
+      validate_metadata!(data)
+      data
+    rescue Errno::ENOENT
+      raise Error, "SFW metadata not found: #{config_path}"
+    end
+
+    def validate_metadata!(data)
+      required = %w[version asset url sha256 size github_digest upstream_repo release_api_url license]
+      missing = required.select { |key| !data.is_a?(Hash) || data[key].nil? || data[key].to_s.empty? }
+      raise Error, "SFW metadata missing required keys: #{missing.join(", ")}" unless missing.empty?
+      raise Error, "SFW metadata sha256 must be lowercase SHA256" unless data.fetch("sha256").match?(SHA256_PATTERN)
+      raise Error, "SFW metadata github_digest must match sha256" unless data.fetch("github_digest") == "#{DIGEST_PREFIX}#{data.fetch("sha256")}"
+      raise Error, "SFW metadata size must be positive" unless data.fetch("size").is_a?(Integer) && data.fetch("size").positive?
+      raise Error, "SFW metadata asset must be macOS arm64" unless data.fetch("asset") == "sfw-free-macos-arm64"
+      raise Error, "SFW metadata URL must be HTTPS" unless data.fetch("url").start_with?("https://")
+      raise Error, "SFW metadata release API URL must be HTTPS" unless data.fetch("release_api_url").start_with?("https://")
+      raise Error, "SFW metadata license must be PolyForm Shield" unless data.fetch("license").fetch("name").include?("PolyForm Shield")
+    end
+
+    def verify_release_metadata!
+      release = @release_fetcher.call(metadata.fetch("release_api_url"))
+      raise Error, "SFW release metadata tag mismatch" unless release.fetch("tag_name") == metadata.fetch("version")
+
+      asset = release.fetch("assets").find { |entry| entry.fetch("name") == metadata.fetch("asset") }
+      raise Error, "SFW release metadata missing asset: #{metadata.fetch("asset")}" unless asset
+
+      expected = {
+        "browser_download_url" => metadata.fetch("url"),
+        "size" => metadata.fetch("size"),
+        "digest" => metadata.fetch("github_digest")
+      }
+      expected.each do |key, value|
+        raise Error, "SFW release metadata #{key} mismatch" unless asset.fetch(key) == value
+      end
+    rescue KeyError => e
+      raise Error, "SFW release metadata missing key: #{e.key}"
+    end
+
+    def seed_paths
+      paths = []
+      paths << env["DOTFILES_SFW_ASSET"] if env["DOTFILES_SFW_ASSET"] && !env["DOTFILES_SFW_ASSET"].empty?
+      paths << File.join(home, "Downloads", metadata.fetch("asset"))
+      paths << File.join(ROOT, ".dotfiles/cache/sfw", metadata.fetch("asset"))
+      paths
+    end
+
+    def valid_seed_path
+      seed_paths.each_with_index do |path, index|
+        next unless File.file?(path)
+
+        if valid_asset?(path)
+          out.puts "Socket Firewall binary: using verified local asset #{path}"
+          return path
+        end
+
+        raise Error, "DOTFILES_SFW_ASSET failed SFW verification: #{path}" if index.zero? && env["DOTFILES_SFW_ASSET"]
+
+        out.puts "Socket Firewall binary: ignoring unverified local asset #{path}"
+      end
+      nil
+    end
+
+    def valid_asset?(path)
+      File.size(path) == metadata.fetch("size") && actual_sha256(path) == expected_sha256
+    end
+
+    def download_asset
+      cache_dir = File.join(ROOT, ".dotfiles/cache/sfw")
+      FileUtils.mkdir_p(cache_dir)
+      destination = File.join(cache_dir, metadata.fetch("asset"))
+      tmp = "#{destination}.tmp"
+      FileUtils.rm_f(tmp)
+      out.puts "Socket Firewall binary: downloading #{metadata.fetch("url")}"
+      @downloader.call(metadata.fetch("url"), tmp)
+      raise Error, "downloaded SFW asset failed verification" unless valid_asset?(tmp)
+
+      FileUtils.mv(tmp, destination)
+      destination
+    ensure
+      FileUtils.rm_f(tmp) if tmp && File.exist?(tmp)
+    end
+
+    def install_source(source)
+      FileUtils.mkdir_p(File.dirname(target_path))
+      tmp = "#{target_path}.tmp"
+      FileUtils.cp(source, tmp)
+      FileUtils.chmod(0o755, tmp)
+      raise Error, "installed SFW binary failed verification" unless matching?(tmp)
+
+      backup_existing_target
+      FileUtils.mv(tmp, target_path)
+      handle_quarantine(target_path)
+      out.puts "Socket Firewall binary: installed #{target_path}"
+    ensure
+      FileUtils.rm_f(tmp) if tmp && File.exist?(tmp)
+    end
+
+    def repair_matching_target(dry_run:)
+      if File.executable?(target_path)
+        out.puts "Socket Firewall binary: already converged at #{target_path}"
+        return
+      end
+
+      if dry_run
+        out.puts "Socket Firewall binary: would repair executable mode on #{target_path}"
+        return
+      end
+
+      FileUtils.chmod(0o755, target_path)
+      handle_quarantine(target_path)
+      out.puts "Socket Firewall binary: repaired executable mode on #{target_path}"
+    end
+
+    def backup_existing_target
+      return unless File.exist?(target_path) || File.symlink?(target_path)
+
+      backup = Runtime.unique_path("#{target_path}.bak")
+      FileUtils.mv(target_path, backup)
+      out.puts "Socket Firewall binary: backed up existing target to #{backup}"
+    end
+
+    def handle_quarantine(path)
+      signing = signing_status(path)
+      case signing
+      when "valid"
+        out.puts "Socket Firewall binary: signed binary verified; leaving quarantine attributes unchanged"
+      when "unsigned"
+        @command_runner.call(["/usr/bin/xattr", "-d", "com.apple.quarantine", path])
+        out.puts "Socket Firewall binary: removed quarantine attribute for unsigned binary"
+      else
+        raise Error, "SFW binary signature verification failed"
+      end
+    end
+
+    def signing_status(path)
+      result = @command_runner.call(["/usr/bin/codesign", "--verify", "--strict", "--verbose=2", path])
+      return "valid" if result.success?
+
+      output = "#{result.stdout}\n#{result.stderr}"
+      return "unsigned" if output.include?("code object is not signed") || output.include?("is not signed at all")
+
+      "invalid"
+    end
+
+    def quarantine_status(path)
+      return "missing" unless File.file?(path)
+
+      result = @command_runner.call(["/usr/bin/xattr", "-p", "com.apple.quarantine", path])
+      result.success? ? "present" : "absent"
+    end
+
+    def executable_status(path)
+      return "missing" unless File.file?(path)
+
+      File.executable?(path) ? "ok" : "not-executable"
+    end
+
+    def fetch_release(url)
+      uri = URI(url)
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") do |http|
+        request = Net::HTTP::Get.new(uri)
+        request["Accept"] = "application/vnd.github+json"
+        request["User-Agent"] = "dotfiles-sfw-installer"
+        http.request(request)
+      end
+      raise Error, "failed to fetch SFW release metadata: HTTP #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+      JSON.parse(response.body)
+    rescue JSON::ParserError => e
+      raise Error, "failed to parse SFW release metadata: #{e.message}"
+    end
+
+    def download(url, destination, limit = 5)
+      raise Error, "too many redirects while downloading SFW binary" if limit.zero?
+
+      uri = URI(url)
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") do |http|
+        request = Net::HTTP::Get.new(uri)
+        request["User-Agent"] = "dotfiles-sfw-installer"
+        http.request(request) do |response|
+          case response
+          when Net::HTTPSuccess
+            File.open(destination, "wb") { |file| response.read_body { |chunk| file.write(chunk) } }
+          when Net::HTTPRedirection
+            return download(URI.join(url, response["location"]).to_s, destination, limit - 1)
+          else
+            raise Error, "failed to download SFW binary: HTTP #{response.code}"
+          end
+        end
+      end
+    end
+
+    def run_command(command)
+      stdout, stderr, status = Open3.capture3(*command)
+      CommandResult.new(success: status.success?, stdout: stdout, stderr: stderr)
+    end
+  end
+end

--- a/lib/dotfiles/socket_firewall.rb
+++ b/lib/dotfiles/socket_firewall.rb
@@ -3,6 +3,7 @@
 require "shellwords"
 
 require_relative "manifest"
+require_relative "sfw_binary"
 
 module Dotfiles
   class SocketFirewall
@@ -20,7 +21,7 @@ module Dotfiles
 
     attr_reader :argv, :out, :err, :env, :home, :root
 
-    def initialize(argv:, out: $stdout, err: $stderr, runner: DEFAULT_RUNNER, env: ENV, home: ENV.fetch("HOME"), root: ROOT)
+    def initialize(argv:, out: $stdout, err: $stderr, runner: DEFAULT_RUNNER, env: ENV, home: ENV.fetch("HOME"), root: ROOT, sfw_binary: nil)
       @argv = argv.dup
       @out = out
       @err = err
@@ -28,8 +29,10 @@ module Dotfiles
       @env = env
       @home = home
       @root = root
+      @sfw_binary = sfw_binary
       @command = "status"
       @dry_run = false
+      @verify_path = nil
     end
 
     def run
@@ -37,6 +40,8 @@ module Dotfiles
       case @command
       when "install"
         install
+      when "verify"
+        verify
       when "doctor"
         doctor
       when "cache-clean"
@@ -56,6 +61,10 @@ module Dotfiles
 
     def shim_dir
       env.fetch("DOTFILES_SFW_SHIM_DIR", File.join(home, ".local/share/dotfiles/sfw-shims"))
+    end
+
+    def sfw_bin
+      env.fetch("DOTFILES_SFW_BIN", File.join(home, ".local/bin/sfw"))
     end
 
     def path_without_shims(path = env.fetch("PATH", ""))
@@ -79,9 +88,11 @@ module Dotfiles
       unprotected = path_without_shims
       {
         "shim_dir" => shim_dir,
+        "sfw_bin" => sfw_bin,
         "require" => env.fetch("DOTFILES_SFW_REQUIRE", "1"),
         "disabled" => env.fetch("DOTFILES_SFW_DISABLE", "0"),
         "protected_path" => protected,
+        "binary" => sfw_binary.status,
         "commands" => STATUS_COMMANDS.map do |command|
           {
             "name" => command,
@@ -96,6 +107,11 @@ module Dotfiles
       lines = [
         "Socket Firewall status",
         "  shim dir:     #{data.fetch("shim_dir")}",
+        "  binary:       #{data.fetch("sfw_bin")}",
+        "  binary hash:  #{data.fetch("binary").fetch("hash_status")}",
+        "  executable:   #{data.fetch("binary").fetch("executable_status")}",
+        "  signing:      #{data.fetch("binary").fetch("signing_status")}",
+        "  quarantine:   #{data.fetch("binary").fetch("quarantine_status")}",
         "  require mode: #{data.fetch("require")}",
         "  disabled:     #{data.fetch("disabled")}",
         ""
@@ -115,6 +131,7 @@ module Dotfiles
         [shell_environment_policy.set]
         DOTFILES_SFW_REQUIRE = #{toml_string(env.fetch("DOTFILES_SFW_REQUIRE", "1"))}
         DOTFILES_SFW_SHIM_DIR = #{toml_string(shim_dir)}
+        DOTFILES_SFW_BIN = #{toml_string(sfw_bin)}
         PATH = #{toml_string(protected_path)}
       TOML
     end
@@ -123,6 +140,7 @@ module Dotfiles
 
     def parse_args!
       @command = argv.shift if argv.first && !argv.first.start_with?("-")
+      @verify_path = argv.shift if @command == "verify" && argv.first && !argv.first.start_with?("-")
       until argv.empty?
         arg = argv.shift
         case arg
@@ -139,28 +157,27 @@ module Dotfiles
 
     def usage
       <<~USAGE
-        Usage: script/socket-firewall [status|doctor|install|cache-clean|codex-config] [--dry-run]
+        Usage: script/socket-firewall [status|doctor|install|verify|cache-clean|codex-config] [--dry-run]
       USAGE
     end
 
     def install
       out.puts "Socket Firewall install"
-      run_command({ "DOTFILES_SFW_DISABLE" => "1" }, %w[npm i -g sfw])
-      if command_available?("nodenv")
-        run_command({}, %w[nodenv rehash])
-      else
-        out.puts "nodenv not found; skipped nodenv rehash"
-      end
+      sfw_binary.install(dry_run: @dry_run)
+      0
+    end
+
+    def verify
+      sfw_binary.verify(@verify_path || sfw_bin)
       0
     end
 
     def doctor
       data = status_data
       out.print format_status(data)
-      sfw_row = data.fetch("commands").find { |row| row.fetch("name") == "sfw" }
-      return 0 unless env.fetch("DOTFILES_SFW_REQUIRE", "1") == "1" && sfw_row.fetch("unprotected") == "<missing>"
+      return 0 unless env.fetch("DOTFILES_SFW_REQUIRE", "1") == "1" && !managed_binary_ready?(data.fetch("binary"))
 
-      err.puts "sfw is required but unavailable outside the protected shim directory"
+      err.puts "sfw is required but the managed binary is unavailable, mismatched, or not executable"
       1
     end
 
@@ -187,6 +204,14 @@ module Dotfiles
     def status
       out.print format_status(status_data)
       0
+    end
+
+    def sfw_binary
+      @sfw_binary ||= SFWBinary.new(env: env, home: home, out: out, err: err)
+    end
+
+    def managed_binary_ready?(binary)
+      binary.fetch("hash_status") == "ok" && binary.fetch("executable_status") == "ok"
     end
 
     def command_available?(command)

--- a/local-bin/codex-sfw
+++ b/local-bin/codex-sfw
@@ -4,6 +4,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 export DOTFILES_SFW_SHIM_DIR="${DOTFILES_SFW_SHIM_DIR:-$HOME/.local/share/dotfiles/sfw-shims}"
+export DOTFILES_SFW_BIN="${DOTFILES_SFW_BIN:-$HOME/.local/bin/sfw}"
 export DOTFILES_SFW_REQUIRE="${DOTFILES_SFW_REQUIRE:-1}"
 
 _codex_sfw_prepend_path() {

--- a/script/test
+++ b/script/test
@@ -103,6 +103,7 @@ ruby -c "$ROOT/lib/dotfiles/runtime.rb" >/dev/null
 ruby -c "$ROOT/lib/dotfiles/installer.rb" >/dev/null
 ruby -c "$ROOT/lib/dotfiles/restorer.rb" >/dev/null
 ruby -c "$ROOT/lib/dotfiles/socket_firewall.rb" >/dev/null
+ruby -c "$ROOT/lib/dotfiles/sfw_binary.rb" >/dev/null
 ruby -c "$ROOT/lib/dotfiles/doctor.rb" >/dev/null
 ruby -c "$ROOT/lib/dotfiles/vendor.rb" >/dev/null
 ruby -c "$ROOT/lib/dotfiles/test_checks.rb" >/dev/null

--- a/shell/functions/socket-firewall.bash
+++ b/shell/functions/socket-firewall.bash
@@ -34,21 +34,23 @@ _dotfiles_sfw_exec() {
     fi
 
     local clean_path
+    local sfw_bin
     clean_path="$(_dotfiles_sfw_path_without_shims)"
+    sfw_bin="${DOTFILES_SFW_BIN:-$HOME/.local/bin/sfw}"
 
     if [ "${DOTFILES_SFW_DISABLE:-0}" = "1" ]; then
         PATH="$clean_path" command "$cmd" "$@"
         return $?
     fi
 
-    if ! PATH="$clean_path" command -v sfw >/dev/null 2>&1; then
+    if [ ! -x "$sfw_bin" ]; then
         if [ "${DOTFILES_SFW_REQUIRE:-1}" = "1" ]; then
-            printf "dotfiles: refusing to run %s unprotected because sfw is unavailable\n" "$cmd" >&2
-            printf "dotfiles: install with: DOTFILES_SFW_DISABLE=1 npm i -g sfw && nodenv rehash\n" >&2
+            printf "dotfiles: refusing to run %s unprotected because DOTFILES_SFW_BIN is unavailable\n" "$cmd" >&2
+            printf "dotfiles: install with: script/socket-firewall install\n" >&2
             return 127
         fi
 
-        printf "dotfiles: warning: sfw unavailable; running %s unprotected\n" "$cmd" >&2
+        printf "dotfiles: warning: DOTFILES_SFW_BIN unavailable; running %s unprotected\n" "$cmd" >&2
         PATH="$clean_path" command "$cmd" "$@"
         return $?
     fi
@@ -58,7 +60,7 @@ _dotfiles_sfw_exec() {
         return 127
     fi
 
-    PATH="$clean_path" command sfw "$cmd" "$@"
+    PATH="$clean_path" "$sfw_bin" "$cmd" "$@"
 }
 
 sfw_status() {
@@ -70,6 +72,7 @@ sfw_status() {
 
     printf "Socket Firewall status\n"
     printf "  shim dir:     %s\n" "$shim_dir"
+    printf "  binary:       %s\n" "${DOTFILES_SFW_BIN:-$HOME/.local/bin/sfw}"
     printf "  require mode: %s\n" "${DOTFILES_SFW_REQUIRE:-1}"
     printf "  disabled:     %s\n" "${DOTFILES_SFW_DISABLE:-0}"
     printf "\n"

--- a/shell/sfw/package-manager-shim.bash
+++ b/shell/sfw/package-manager-shim.bash
@@ -14,6 +14,7 @@ case "$cmd" in
 esac
 
 shim_dir="${DOTFILES_SFW_SHIM_DIR:-$HOME/.local/share/dotfiles/sfw-shims}"
+sfw_bin="${DOTFILES_SFW_BIN:-$HOME/.local/bin/sfw}"
 
 path_without_shims() {
     local old_ifs="$IFS"
@@ -35,27 +36,27 @@ clean_path="$(path_without_shims)"
 export PATH="$clean_path"
 
 if [ "$cmd" = "sfw" ]; then
-    if ! command -v sfw >/dev/null 2>&1; then
-        printf "dotfiles-sfw-shim: real sfw not found after removing shim dir\n" >&2
-        printf "dotfiles-sfw-shim: install with: DOTFILES_SFW_DISABLE=1 npm i -g sfw && nodenv rehash\n" >&2
+    if [ ! -x "$sfw_bin" ]; then
+        printf "dotfiles-sfw-shim: DOTFILES_SFW_BIN not found or not executable: %s\n" "$sfw_bin" >&2
+        printf "dotfiles-sfw-shim: install with: script/socket-firewall install\n" >&2
         exit 127
     fi
 
-    exec sfw "$@"
+    exec "$sfw_bin" "$@"
 fi
 
 if [ "${DOTFILES_SFW_DISABLE:-0}" = "1" ]; then
     exec "$cmd" "$@"
 fi
 
-if ! command -v sfw >/dev/null 2>&1; then
+if [ ! -x "$sfw_bin" ]; then
     if [ "${DOTFILES_SFW_REQUIRE:-1}" = "1" ]; then
-        printf "dotfiles-sfw-shim: refusing to run %s unprotected because sfw is unavailable\n" "$cmd" >&2
-        printf "dotfiles-sfw-shim: install with: DOTFILES_SFW_DISABLE=1 npm i -g sfw && nodenv rehash\n" >&2
+        printf "dotfiles-sfw-shim: refusing to run %s unprotected because DOTFILES_SFW_BIN is unavailable\n" "$cmd" >&2
+        printf "dotfiles-sfw-shim: install with: script/socket-firewall install\n" >&2
         exit 127
     fi
 
-    printf "dotfiles-sfw-shim: warning: sfw unavailable; running %s unprotected\n" "$cmd" >&2
+    printf "dotfiles-sfw-shim: warning: DOTFILES_SFW_BIN unavailable; running %s unprotected\n" "$cmd" >&2
     exec "$cmd" "$@"
 fi
 
@@ -64,4 +65,4 @@ if ! command -v "$cmd" >/dev/null 2>&1; then
     exit 127
 fi
 
-exec sfw "$cmd" "$@"
+exec "$sfw_bin" "$cmd" "$@"

--- a/shell/socket-firewall.bash
+++ b/shell/socket-firewall.bash
@@ -6,6 +6,7 @@
 # directory outranks nodenv, pyenv, Cargo, and system package-manager paths.
 
 export DOTFILES_SFW_SHIM_DIR="${DOTFILES_SFW_SHIM_DIR:-$HOME/.local/share/dotfiles/sfw-shims}"
+export DOTFILES_SFW_BIN="${DOTFILES_SFW_BIN:-$HOME/.local/bin/sfw}"
 export DOTFILES_SFW_REQUIRE="${DOTFILES_SFW_REQUIRE:-1}"
 
 if [ "${DOTFILES_SFW_DISABLE:-0}" != "1" ]; then

--- a/spec/lib/installer_spec.rb
+++ b/spec/lib/installer_spec.rb
@@ -33,7 +33,11 @@ RSpec.describe Dotfiles::Installer do
     instance_double(Dotfiles::VSCode::Manager, actions: actions, apply: true)
   end
 
-  def run_installer(argv:, entries:, manager: vscode_manager, platform: "arm64-darwin25", state_dir: nil, default_directories: [])
+  def sfw_binary
+    instance_double(Dotfiles::SFWBinary, install: true)
+  end
+
+  def run_installer(argv:, entries:, manager: vscode_manager, sfw: sfw_binary, platform: "arm64-darwin25", state_dir: nil, default_directories: [])
     stdout = StringIO.new
     stderr = StringIO.new
     installer = described_class.new(
@@ -43,6 +47,7 @@ RSpec.describe Dotfiles::Installer do
       err: stderr,
       platform: platform,
       manifest: manifest(entries),
+      sfw_binary: sfw,
       vscode_manager: manager,
       state_dir: state_dir || File.join(@home, "state"),
       default_directories: default_directories,
@@ -205,6 +210,30 @@ RSpec.describe Dotfiles::Installer do
 
     expect(status).to eq(0)
     expect(stdout).to include("VS Code: skipped", "Existing shells may need: source ~/.bashrc")
+  end
+
+  it "installs the Socket Firewall binary through the shared installer" do
+    sfw = sfw_binary
+
+    status, stdout, stderr = run_installer(argv: [], entries: [], sfw: sfw)
+
+    expect(status).to eq(0)
+    expect(stderr).to eq("")
+    expect(stdout).to include("Socket Firewall")
+    expect(sfw).to have_received(:install).with(dry_run: false)
+  end
+
+  it "previews or skips the Socket Firewall binary install" do
+    sfw = sfw_binary
+    status, = run_installer(argv: ["--dry-run"], entries: [], sfw: sfw)
+    expect(status).to eq(0)
+    expect(sfw).to have_received(:install).with(dry_run: true)
+
+    skipped = sfw_binary
+    status, stdout, = run_installer(argv: ["--skip-sfw-binary"], entries: [], sfw: skipped)
+    expect(status).to eq(0)
+    expect(stdout).to include("Socket Firewall binary: skipped")
+    expect(skipped).not_to have_received(:install)
   end
 
   it "reports unsupported install modes from manifest entries" do

--- a/spec/lib/installer_spec.rb
+++ b/spec/lib/installer_spec.rb
@@ -172,6 +172,24 @@ RSpec.describe Dotfiles::Installer do
     expect(Dir[File.join(@home, "dotfiles_old/.config/readme*")].length).to eq(1)
   end
 
+  it "writes restore state before the fallible Socket Firewall step" do
+    target = File.join(@home, ".config/readme")
+    state_dir = File.join(@home, "state")
+    FileUtils.mkdir_p(File.dirname(target))
+    File.write(target, "old")
+    copy_entry = entry("mode" => "copy")
+    sfw = sfw_binary
+    allow(sfw).to receive(:install).and_raise(Dotfiles::Error, "broken sfw")
+
+    status, stdout, stderr = run_installer(argv: [], entries: [copy_entry], sfw: sfw, state_dir: state_dir)
+
+    expect(status).to eq(1)
+    expect(stdout).to include("copied readme", "Install state:")
+    expect(stderr).to eq("broken sfw\n")
+    state = Dir[File.join(state_dir, "install-*.tsv")].first
+    expect(File.read(state)).to include("readme", "copied", "dotfiles_old/.config/readme")
+  end
+
   it "previews backups and copy operations in dry-run mode" do
     target = File.join(@home, ".config/readme")
     FileUtils.mkdir_p(File.dirname(target))

--- a/spec/lib/sfw_binary_spec.rb
+++ b/spec/lib/sfw_binary_spec.rb
@@ -1,0 +1,369 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../lib/dotfiles/sfw_binary"
+
+RSpec.describe Dotfiles::SFWBinary do
+  def digest_for(content)
+    Digest::SHA256.hexdigest(content)
+  end
+
+  def metadata_file(dir, content: "binary")
+    sha = digest_for(content)
+    path = File.join(dir, "sfw.yml")
+    File.write(path, {
+      "version" => "vtest",
+      "asset" => "sfw-free-macos-arm64",
+      "url" => "https://github.com/SocketDev/sfw-free/releases/download/vtest/sfw-free-macos-arm64",
+      "sha256" => sha,
+      "size" => content.bytesize,
+      "github_digest" => "sha256:#{sha}",
+      "upstream_repo" => "SocketDev/sfw-free",
+      "release_api_url" => "https://api.github.com/repos/SocketDev/sfw-free/releases/tags/vtest",
+      "license" => {
+        "name" => "PolyForm Shield License 1.0.0",
+        "url" => "https://github.com/SocketDev/sfw-free#license"
+      }
+    }.to_yaml)
+    path
+  end
+
+  def release_for(binary)
+    {
+      "tag_name" => binary.metadata.fetch("version"),
+      "assets" => [
+        {
+          "name" => binary.metadata.fetch("asset"),
+          "browser_download_url" => binary.metadata.fetch("url"),
+          "size" => binary.metadata.fetch("size"),
+          "digest" => binary.metadata.fetch("github_digest")
+        }
+      ]
+    }
+  end
+
+  def command_result(success:, stdout: "", stderr: "")
+    Dotfiles::SFWBinary::CommandResult.new(success: success, stdout: stdout, stderr: stderr)
+  end
+
+  def build(config_path:, env:, home:, release: nil, downloader: nil, commands: [])
+    command_runner = lambda do |_command|
+      commands.empty? ? command_result(success: true) : commands.shift
+    end
+    binary = nil
+    release_fetcher = release || ->(_url) { release_for(binary) }
+    binary = described_class.new(
+      config_path: config_path,
+      env: env,
+      home: home,
+      out: StringIO.new,
+      err: StringIO.new,
+      release_fetcher: release_fetcher,
+      downloader: downloader || ->(_url, path) { File.write(path, "binary") },
+      command_runner: command_runner
+    )
+    binary
+  end
+
+  class FakeHTTPSuccess < Net::HTTPSuccess
+    attr_reader :code, :body
+
+    def initialize(body: "")
+      @code = "200"
+      @body = body
+    end
+
+    def read_body
+      yield body
+    end
+  end
+
+  class FakeHTTPRedirect < Net::HTTPRedirection
+    attr_reader :code
+
+    def initialize(location:)
+      @code = "302"
+      @location = location
+    end
+
+    def [](key)
+      key == "location" ? @location : nil
+    end
+  end
+
+  class FakeHTTPError < Net::HTTPResponse
+    attr_reader :code
+
+    def initialize(code:)
+      @code = code
+    end
+  end
+
+  class FakeHTTP
+    def initialize(response)
+      @response = response
+    end
+
+    def request(_request)
+      if block_given?
+        yield @response
+      else
+        @response
+      end
+    end
+  end
+
+  def stub_net_http(*responses)
+    queue = responses.dup
+    allow(Net::HTTP).to receive(:start) do |_host, _port, use_ssl:, &block|
+      expect(use_ssl).to eq(true)
+      block.call(FakeHTTP.new(queue.shift))
+    end
+  end
+
+  it "loads metadata and verifies an existing matching binary" do
+    Dir.mktmpdir do |dir|
+      config = metadata_file(dir)
+      target = File.join(dir, "bin/sfw")
+      FileUtils.mkdir_p(File.dirname(target))
+      File.write(target, "binary")
+      FileUtils.chmod(0o755, target)
+      binary = described_class.new(
+        config_path: config,
+        env: { "DOTFILES_SFW_BIN" => target },
+        home: dir,
+        out: StringIO.new,
+        err: StringIO.new,
+        command_runner: ->(_command) { command_result(success: true) }
+      )
+
+      expect(binary.target_path).to eq(target)
+      expect(binary.expected_sha256).to eq(digest_for("binary"))
+      expect(binary.actual_sha256(target)).to eq(digest_for("binary"))
+      expect(binary.matching?).to eq(true)
+      expect(binary.install).to eq(true)
+      expect(binary.out.string).to include("already converged")
+      expect(binary.verify).to eq(true)
+      expect(binary.out.string).to include("status:   ok")
+      expect(binary.status).to include(
+        "hash_status" => "ok",
+        "executable_status" => "ok",
+        "signing_status" => "valid",
+        "quarantine_status" => "present"
+      )
+    end
+  end
+
+  it "repairs executable mode for a matching target without network access" do
+    Dir.mktmpdir do |dir|
+      config = metadata_file(dir)
+      target = File.join(dir, ".local/bin/sfw")
+      FileUtils.mkdir_p(File.dirname(target))
+      File.write(target, "binary")
+      FileUtils.chmod(0o644, target)
+      binary = described_class.new(
+        config_path: config,
+        env: {},
+        home: dir,
+        out: StringIO.new,
+        err: StringIO.new,
+        release_fetcher: ->(_url) { raise "should not fetch" },
+        downloader: ->(_url, _path) { raise "should not download" },
+        command_runner: ->(_command) { command_result(success: true) }
+      )
+
+      expect(binary.status).to include("hash_status" => "ok", "executable_status" => "not-executable")
+      expect(binary.install).to eq(true)
+      expect(File.stat(target).mode & 0o777).to eq(0o755)
+      expect(binary.out.string).to include("repaired executable mode")
+    end
+  end
+
+  it "previews executable mode repair for a matching target" do
+    Dir.mktmpdir do |dir|
+      config = metadata_file(dir)
+      target = File.join(dir, ".local/bin/sfw")
+      FileUtils.mkdir_p(File.dirname(target))
+      File.write(target, "binary")
+      FileUtils.chmod(0o644, target)
+      binary = described_class.new(
+        config_path: config,
+        env: {},
+        home: dir,
+        out: StringIO.new,
+        err: StringIO.new,
+        release_fetcher: ->(_url) { raise "should not fetch" },
+        downloader: ->(_url, _path) { raise "should not download" }
+      )
+
+      expect(binary.install(dry_run: true)).to eq(true)
+      expect(File.stat(target).mode & 0o777).to eq(0o644)
+      expect(binary.out.string).to include("would repair executable mode")
+    end
+  end
+
+  it "reports missing and mismatched verification failures" do
+    Dir.mktmpdir do |dir|
+      config = metadata_file(dir)
+      missing = described_class.new(config_path: config, env: {}, home: dir, out: StringIO.new, err: StringIO.new)
+      expect { missing.verify }.to raise_error(Dotfiles::Error, /missing/)
+
+      target = File.join(dir, ".local/bin/sfw")
+      FileUtils.mkdir_p(File.dirname(target))
+      File.write(target, "wrong")
+      mismatch = described_class.new(config_path: config, env: {}, home: dir, out: StringIO.new, err: StringIO.new)
+      expect(mismatch.matching?).to eq(false)
+      expect { mismatch.verify }.to raise_error(Dotfiles::Error, /SHA256 mismatch/)
+      expect(mismatch.status).to include("hash_status" => "mismatch", "executable_status" => "not-executable")
+    end
+  end
+
+  it "previews missing installs without network or filesystem mutation" do
+    Dir.mktmpdir do |dir|
+      config = metadata_file(dir)
+      binary = described_class.new(
+        config_path: config,
+        env: {},
+        home: dir,
+        out: StringIO.new,
+        err: StringIO.new,
+        release_fetcher: ->(_url) { raise "should not fetch" },
+        downloader: ->(_url, _path) { raise "should not download" }
+      )
+
+      expect(binary.install(dry_run: true)).to eq(true)
+      expect(binary.out.string).to include("would install sfw-free-macos-arm64")
+      expect(File).not_to exist(File.join(dir, ".local/bin/sfw"))
+    end
+  end
+
+  it "installs from a verified local seed and backs up an existing target" do
+    Dir.mktmpdir do |dir|
+      config = metadata_file(dir)
+      seed = File.join(dir, "Downloads/sfw-free-macos-arm64")
+      target = File.join(dir, ".local/bin/sfw")
+      FileUtils.mkdir_p(File.dirname(seed))
+      FileUtils.mkdir_p(File.dirname(target))
+      File.write(seed, "binary")
+      File.write(target, "old")
+      commands = [
+        command_result(success: false, stderr: "code object is not signed at all"),
+        command_result(success: false)
+      ]
+      binary = build(config_path: config, env: {}, home: dir, commands: commands)
+
+      expect(binary.install).to eq(true)
+      expect(File.read(target)).to eq("binary")
+      expect(File.stat(target).mode & 0o777).to eq(0o755)
+      expect(Dir[File.join(dir, ".local/bin/sfw.bak*")].length).to eq(1)
+      expect(binary.out.string).to include(
+        "using verified local asset",
+        "removed quarantine attribute for unsigned binary",
+        "installed #{target}"
+      )
+    end
+  end
+
+  it "downloads when no local seed is available" do
+    Dir.mktmpdir do |dir|
+      config = metadata_file(dir, content: "downloaded")
+      target = File.join(dir, ".local/bin/sfw")
+      binary = build(
+        config_path: config,
+        env: {},
+        home: dir,
+        downloader: ->(_url, path) { File.write(path, "downloaded") },
+        commands: [command_result(success: true)]
+      )
+
+      expect(binary.install).to eq(true)
+      expect(File.read(target)).to eq("downloaded")
+      expect(File).to exist(File.join(Dotfiles::ROOT, ".dotfiles/cache/sfw/sfw-free-macos-arm64"))
+      expect(binary.out.string).to include("downloading", "signed binary verified")
+    ensure
+      FileUtils.rm_f(File.join(Dotfiles::ROOT, ".dotfiles/cache/sfw/sfw-free-macos-arm64"))
+    end
+  end
+
+  it "rejects invalid explicit seed, invalid release metadata, bad downloads, and invalid signatures" do
+    Dir.mktmpdir do |dir|
+      config = metadata_file(dir)
+      explicit = File.join(dir, "bad-sfw")
+      File.write(explicit, "wrong")
+      explicit_binary = build(config_path: config, env: { "DOTFILES_SFW_ASSET" => explicit }, home: dir)
+      expect { explicit_binary.install }.to raise_error(Dotfiles::Error, /DOTFILES_SFW_ASSET failed/)
+
+      bad_release = build(config_path: config, env: {}, home: dir, release: ->(_url) { { "tag_name" => "bad", "assets" => [] } })
+      expect { bad_release.install }.to raise_error(Dotfiles::Error, /tag mismatch/)
+
+      missing_key = build(config_path: config, env: {}, home: dir, release: ->(_url) { { "assets" => [] } })
+      expect { missing_key.install }.to raise_error(Dotfiles::Error, /missing key/)
+
+      default_seed = File.join(dir, "Downloads/sfw-free-macos-arm64")
+      FileUtils.mkdir_p(File.dirname(default_seed))
+      File.write(default_seed, "wrong")
+      ignored_seed = build(config_path: config, env: {}, home: dir, commands: [command_result(success: true)])
+      expect(ignored_seed.install).to eq(true)
+      expect(ignored_seed.out.string).to include("ignoring unverified local asset")
+      FileUtils.rm_f(default_seed)
+      FileUtils.rm_f(File.join(dir, ".local/bin/sfw"))
+      FileUtils.rm_f(File.join(Dotfiles::ROOT, ".dotfiles/cache/sfw/sfw-free-macos-arm64"))
+
+      bad_download = build(config_path: config, env: {}, home: dir, downloader: ->(_url, path) { File.write(path, "wrong") })
+      expect { bad_download.install }.to raise_error(Dotfiles::Error, /downloaded SFW asset failed/)
+
+      seed = File.join(dir, "Downloads/sfw-free-macos-arm64")
+      FileUtils.mkdir_p(File.dirname(seed))
+      File.write(seed, "binary")
+      FileUtils.rm_f(File.join(dir, ".local/bin/sfw"))
+      invalid_signature = build(config_path: config, env: {}, home: dir, commands: [command_result(success: false, stderr: "rejected")])
+      expect { invalid_signature.install }.to raise_error(Dotfiles::Error, /signature verification failed/)
+    end
+  end
+
+  it "validates metadata shape" do
+    Dir.mktmpdir do |dir|
+      missing = File.join(dir, "missing.yml")
+      expect { described_class.new(config_path: missing, env: {}, home: dir).metadata }.to raise_error(Dotfiles::Error, /not found/)
+
+      invalid = File.join(dir, "invalid.yml")
+      File.write(invalid, {
+        "version" => "v",
+        "asset" => "bad",
+        "url" => "http://example.com",
+        "sha256" => "bad",
+        "size" => 0,
+        "github_digest" => "sha256:bad",
+        "upstream_repo" => "SocketDev/sfw-free",
+        "release_api_url" => "http://example.com",
+        "license" => { "name" => "MIT" }
+      }.to_yaml)
+
+      expect { described_class.new(config_path: invalid, env: {}, home: dir).metadata }.to raise_error(Dotfiles::Error, /sha256/)
+
+      missing_key = File.join(dir, "missing-key.yml")
+      File.write(missing_key, {}.to_yaml)
+      expect { described_class.new(config_path: missing_key, env: {}, home: dir).metadata }.to raise_error(Dotfiles::Error, /missing required keys/)
+    end
+  end
+
+  it "fetches release metadata and downloads assets over HTTP" do
+    stub_net_http(
+      FakeHTTPSuccess.new(body: "{\"tag_name\":\"v\",\"assets\":[]}"),
+      FakeHTTPRedirect.new(location: "/asset"),
+      FakeHTTPSuccess.new(body: "asset"),
+      FakeHTTPError.new(code: "500"),
+      FakeHTTPSuccess.new(body: "nope")
+    )
+    binary = described_class.new(config_path: metadata_file(Dir.mktmpdir), env: {}, home: Dir.mktmpdir)
+    expect(binary.send(:fetch_release, "https://example.test/release")).to eq({ "tag_name" => "v", "assets" => [] })
+
+    destination = File.join(Dir.mktmpdir, "asset")
+    binary.send(:download, "https://example.test/redirect", destination)
+    expect(File.read(destination)).to eq("asset")
+
+    expect { binary.send(:download, "https://example.test/fail", destination) }.to raise_error(Dotfiles::Error, /HTTP 500/)
+    expect { binary.send(:fetch_release, "https://example.test/bad-json") }.to raise_error(Dotfiles::Error, /parse/)
+    expect { binary.send(:download, "https://example.test/loop", destination, 0) }.to raise_error(Dotfiles::Error, /too many redirects/)
+  end
+end

--- a/spec/lib/sfw_binary_spec.rb
+++ b/spec/lib/sfw_binary_spec.rb
@@ -218,6 +218,42 @@ RSpec.describe Dotfiles::SFWBinary do
     end
   end
 
+  it "reports missing macOS signing tools as unavailable in status" do
+    Dir.mktmpdir do |dir|
+      config = metadata_file(dir)
+      target = File.join(dir, ".local/bin/sfw")
+      FileUtils.mkdir_p(File.dirname(target))
+      File.write(target, "binary")
+      FileUtils.chmod(0o755, target)
+      binary = build(
+        config_path: config,
+        env: {},
+        home: dir,
+        commands: [
+          command_result(success: false, stderr: "command not found: /usr/bin/codesign"),
+          command_result(success: false, stderr: "command not found: /usr/bin/xattr")
+        ]
+      )
+
+      expect(binary.status).to include(
+        "hash_status" => "ok",
+        "executable_status" => "ok",
+        "signing_status" => "unavailable",
+        "quarantine_status" => "unavailable"
+      )
+    end
+  end
+
+  it "turns missing command execution into a failed command result" do
+    Dir.mktmpdir do |dir|
+      binary = described_class.new(config_path: metadata_file(dir), env: {}, home: dir)
+      result = binary.send(:run_command, [File.join(dir, "missing-command")])
+
+      expect(result).not_to be_success
+      expect(result.stderr).to include("command not found:")
+    end
+  end
+
   it "previews missing installs without network or filesystem mutation" do
     Dir.mktmpdir do |dir|
       config = metadata_file(dir)
@@ -246,11 +282,7 @@ RSpec.describe Dotfiles::SFWBinary do
       FileUtils.mkdir_p(File.dirname(target))
       File.write(seed, "binary")
       File.write(target, "old")
-      commands = [
-        command_result(success: false, stderr: "code object is not signed at all"),
-        command_result(success: false)
-      ]
-      binary = build(config_path: config, env: {}, home: dir, commands: commands)
+      binary = build(config_path: config, env: {}, home: dir, commands: [command_result(success: true)])
 
       expect(binary.install).to eq(true)
       expect(File.read(target)).to eq("binary")
@@ -258,9 +290,27 @@ RSpec.describe Dotfiles::SFWBinary do
       expect(Dir[File.join(dir, ".local/bin/sfw.bak*")].length).to eq(1)
       expect(binary.out.string).to include(
         "using verified local asset",
-        "removed quarantine attribute for unsigned binary",
+        "signed binary verified",
         "installed #{target}"
       )
+    end
+  end
+
+  it "rejects unsigned binaries even when their hash matches" do
+    Dir.mktmpdir do |dir|
+      config = metadata_file(dir)
+      seed = File.join(dir, "Downloads/sfw-free-macos-arm64")
+      FileUtils.mkdir_p(File.dirname(seed))
+      File.write(seed, "binary")
+      binary = build(
+        config_path: config,
+        env: {},
+        home: dir,
+        commands: [command_result(success: false, stderr: "code object is not signed at all")]
+      )
+
+      expect { binary.install }.to raise_error(Dotfiles::Error, /signature verification failed/)
+      expect(File).not_to exist(File.join(dir, ".local/bin/sfw"))
     end
   end
 

--- a/spec/lib/sfw_binary_spec.rb
+++ b/spec/lib/sfw_binary_spec.rb
@@ -254,6 +254,20 @@ RSpec.describe Dotfiles::SFWBinary do
     end
   end
 
+  it "returns successful command results from the default command runner" do
+    Dir.mktmpdir do |dir|
+      status = instance_double(Process::Status, success?: true)
+      allow(Open3).to receive(:capture3).and_return(["stdout", "stderr", status])
+      binary = described_class.new(config_path: metadata_file(dir), env: {}, home: dir)
+
+      result = binary.send(:run_command, ["/bin/echo", "ok"])
+
+      expect(result).to be_success
+      expect(result.stdout).to eq("stdout")
+      expect(result.stderr).to eq("stderr")
+    end
+  end
+
   it "previews missing installs without network or filesystem mutation" do
     Dir.mktmpdir do |dir|
       config = metadata_file(dir)

--- a/spec/lib/socket_firewall_spec.rb
+++ b/spec/lib/socket_firewall_spec.rb
@@ -12,7 +12,20 @@ RSpec.describe Dotfiles::SocketFirewall do
     path
   end
 
-  def build(argv: [], env: {}, runner: ->(*) { true }, home: "/home/user")
+  def sfw_binary(status: nil)
+    status ||= {
+      "path" => "/home/user/.local/bin/sfw",
+      "expected_sha256" => "e" * 64,
+      "actual_sha256" => "<missing>",
+      "hash_status" => "mismatch",
+      "executable_status" => "missing",
+      "signing_status" => "missing",
+      "quarantine_status" => "missing"
+    }
+    instance_double(Dotfiles::SFWBinary, install: true, verify: true, status: status)
+  end
+
+  def build(argv: [], env: {}, runner: ->(*) { true }, home: "/home/user", sfw: sfw_binary)
     described_class.new(
       argv: argv,
       out: StringIO.new,
@@ -20,7 +33,8 @@ RSpec.describe Dotfiles::SocketFirewall do
       runner: runner,
       env: env,
       home: home,
-      root: ROOT
+      root: ROOT,
+      sfw_binary: sfw
     )
   end
 
@@ -51,6 +65,9 @@ RSpec.describe Dotfiles::SocketFirewall do
         .to include("protected" => npm_shim, "unprotected" => real_npm)
       expect(firewall.format_status(data)).to include(
         "Socket Firewall status",
+        "binary:       /home/user/.local/bin/sfw",
+        "binary hash:  mismatch",
+        "executable:   missing",
         "require mode: 0",
         "disabled:     1",
         "npm    protected:"
@@ -79,64 +96,88 @@ RSpec.describe Dotfiles::SocketFirewall do
         "[shell_environment_policy]",
         "DOTFILES_SFW_REQUIRE = \"1\"",
         "DOTFILES_SFW_SHIM_DIR = \"#{File.join(dir, "shim")}\"",
+        "DOTFILES_SFW_BIN = \"/home/user/.local/bin/sfw\"",
         "PATH = \"#{File.join(dir, "shim")}:#{File.join(dir, "bin")}\""
       )
     end
   end
 
-  it "returns doctor success when real sfw is available outside the shim directory" do
+  it "returns doctor success when the managed sfw binary matches" do
     Dir.mktmpdir do |dir|
       real_dir = File.join(dir, "real")
       executable(real_dir, "sfw")
-      firewall = build(argv: ["doctor"], env: { "PATH" => real_dir })
+      sfw = sfw_binary(status: {
+        "path" => "/home/user/.local/bin/sfw",
+        "expected_sha256" => "e" * 64,
+        "actual_sha256" => "e" * 64,
+        "hash_status" => "ok",
+        "executable_status" => "ok",
+        "signing_status" => "valid",
+        "quarantine_status" => "absent"
+      })
+      firewall = build(argv: ["doctor"], env: { "PATH" => real_dir }, sfw: sfw)
 
       expect(firewall.run).to eq(0)
-      expect(firewall.out.string).to include("sfw    unprotected: #{File.join(real_dir, "sfw")}")
+      expect(firewall.out.string).to include("binary hash:  ok", "sfw    unprotected: #{File.join(real_dir, "sfw")}")
       expect(firewall.err.string).to eq("")
     end
   end
 
-  it "returns doctor failure when sfw is required but unavailable" do
+  it "returns doctor failure when sfw is required but the managed binary is unavailable" do
     firewall = build(argv: ["doctor"], env: { "PATH" => "", "DOTFILES_SFW_REQUIRE" => "1" })
 
     expect(firewall.run).to eq(1)
-    expect(firewall.err.string).to eq("sfw is required but unavailable outside the protected shim directory\n")
+    expect(firewall.err.string).to eq("sfw is required but the managed binary is unavailable, mismatched, or not executable\n")
   end
 
-  it "installs sfw and rehashes nodenv when nodenv is available" do
-    Dir.mktmpdir do |dir|
-      executable(dir, "nodenv")
-      calls = []
-      runner = lambda do |env, *command, chdir:|
-        calls << [env, command, chdir]
-        true
-      end
-      firewall = build(argv: ["install"], env: { "PATH" => dir }, runner: runner)
-
-      expect(firewall.run).to eq(0)
-      expect(calls).to eq([
-        [{ "DOTFILES_SFW_DISABLE" => "1" }, %w[npm i -g sfw], ROOT],
-        [{}, %w[nodenv rehash], ROOT]
-      ])
-      expect(firewall.out.string).to include("Socket Firewall install")
-    end
-  end
-
-  it "supports dry-run installs and skips nodenv rehash when nodenv is missing" do
-    firewall = build(argv: ["install", "--dry-run"], env: { "PATH" => "" }, runner: ->(*) { raise "should not run" })
-
-    expect(firewall.run).to eq(0)
-    expect(firewall.out.string).to include(
-      "would run: DOTFILES_SFW_DISABLE=1 npm i -g sfw",
-      "nodenv not found; skipped nodenv rehash"
-    )
-  end
-
-  it "reports failed install commands" do
-    firewall = build(argv: ["install"], env: { "PATH" => "" }, runner: ->(*) { false })
+  it "returns doctor failure when the managed sfw binary is not executable" do
+    sfw = sfw_binary(status: {
+      "path" => "/home/user/.local/bin/sfw",
+      "expected_sha256" => "e" * 64,
+      "actual_sha256" => "e" * 64,
+      "hash_status" => "ok",
+      "executable_status" => "not-executable",
+      "signing_status" => "valid",
+      "quarantine_status" => "absent"
+    })
+    firewall = build(argv: ["doctor"], env: { "PATH" => "", "DOTFILES_SFW_REQUIRE" => "1" }, sfw: sfw)
 
     expect(firewall.run).to eq(1)
-    expect(firewall.err.string).to eq("command failed: DOTFILES_SFW_DISABLE=1 npm i -g sfw\n")
+    expect(firewall.out.string).to include("binary hash:  ok", "executable:   not-executable")
+  end
+
+  it "installs the managed sfw binary" do
+    sfw = sfw_binary
+    firewall = build(argv: ["install"], env: { "PATH" => "" }, sfw: sfw)
+
+    expect(firewall.run).to eq(0)
+    expect(sfw).to have_received(:install).with(dry_run: false)
+    expect(firewall.out.string).to include("Socket Firewall install")
+  end
+
+  it "supports dry-run installs" do
+    sfw = sfw_binary
+    firewall = build(argv: ["install", "--dry-run"], env: { "PATH" => "" }, sfw: sfw)
+
+    expect(firewall.run).to eq(0)
+    expect(sfw).to have_received(:install).with(dry_run: true)
+  end
+
+  it "verifies the managed sfw binary" do
+    sfw = sfw_binary
+    firewall = build(argv: ["verify", "/tmp/sfw"], sfw: sfw)
+
+    expect(firewall.run).to eq(0)
+    expect(sfw).to have_received(:verify).with("/tmp/sfw")
+  end
+
+  it "reports failed managed sfw binary install" do
+    sfw = sfw_binary
+    allow(sfw).to receive(:install).and_raise(Dotfiles::Error, "broken sfw")
+    firewall = build(argv: ["install"], env: { "PATH" => "" }, sfw: sfw)
+
+    expect(firewall.run).to eq(1)
+    expect(firewall.err.string).to eq("broken sfw\n")
   end
 
   it "cleans package-manager caches with SFW disabled" do
@@ -154,6 +195,16 @@ RSpec.describe Dotfiles::SocketFirewall do
         "would run: rm -fr #{File.join(dir, "cargo/registry")} #{File.join(dir, "cargo/git")}"
       )
       expect(firewall.out.string).not_to include("cargo clean gc")
+    end
+  end
+
+  it "reports failed cache clean commands" do
+    Dir.mktmpdir do |dir|
+      executable(dir, "npm")
+      firewall = build(argv: ["cache-clean"], env: { "PATH" => dir }, runner: ->(*) { false })
+
+      expect(firewall.run).to eq(1)
+      expect(firewall.err.string).to eq("command failed: DOTFILES_SFW_DISABLE=1 npm cache clean --force\n")
     end
   end
 
@@ -189,6 +240,6 @@ RSpec.describe Dotfiles::SocketFirewall do
     expect(bad_option.run).to eq(1)
     expect(bad_option.err.string).to include("Unknown option: --wat", "Usage: script/socket-firewall")
     expect(bad_command.run).to eq(2)
-    expect(bad_command.err.string).to eq("Usage: script/socket-firewall [status|doctor|install|cache-clean|codex-config] [--dry-run]\n")
+    expect(bad_command.err.string).to eq("Usage: script/socket-firewall [status|doctor|install|verify|cache-clean|codex-config] [--dry-run]\n")
   end
 end

--- a/spec/scripts/codex_sfw_spec.rb
+++ b/spec/scripts/codex_sfw_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "codex-sfw launcher" do
         {
           printf 'DOTFILES_SFW_REQUIRE=%s\\n' "$DOTFILES_SFW_REQUIRE"
           printf 'DOTFILES_SFW_SHIM_DIR=%s\\n' "$DOTFILES_SFW_SHIM_DIR"
+          printf 'DOTFILES_SFW_BIN=%s\\n' "$DOTFILES_SFW_BIN"
           printf 'PATH=%s\\n' "$PATH"
           printf 'args=%s\\n' "$*"
         } > "$CAPTURE_PATH"
@@ -35,6 +36,8 @@ RSpec.describe "codex-sfw launcher" do
       _stdout, stderr, status = Open3.capture3(
         {
           "CAPTURE_PATH" => capture_path,
+          "DOTFILES_SFW_BIN" => nil,
+          "DOTFILES_SFW_SHIM_DIR" => nil,
           "HOME" => home,
           "PATH" => "/usr/bin:/bin"
         },
@@ -48,6 +51,7 @@ RSpec.describe "codex-sfw launcher" do
       expect(capture).to include(
         "DOTFILES_SFW_REQUIRE=1",
         "DOTFILES_SFW_SHIM_DIR=#{File.join(home, ".local/share/dotfiles/sfw-shims")}",
+        "DOTFILES_SFW_BIN=#{File.join(home, ".local/bin/sfw")}",
         "args=exec npm --version"
       )
       expect(capture).to include("PATH=#{(expected_paths + ["/usr/bin", "/bin"]).join(File::PATH_SEPARATOR)}")

--- a/spec/scripts/socket_firewall_shim_spec.rb
+++ b/spec/scripts/socket_firewall_shim_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "Socket Firewall package-manager shim" do
         printf 'cmd=npm\\n' >> "$LOG"
       SH
       env = {
+        "DOTFILES_SFW_BIN" => File.join(real_dir, "sfw"),
         "DOTFILES_SFW_SHIM_DIR" => shim_dir,
         "DOTFILES_SFW_REQUIRE" => "1",
         "HOME" => dir,
@@ -77,6 +78,7 @@ RSpec.describe "Socket Firewall package-manager shim" do
         } >> "$LOG"
       SH
       env = {
+        "DOTFILES_SFW_BIN" => File.join(real_dir, "sfw"),
         "DOTFILES_SFW_SHIM_DIR" => shim_dir,
         "HOME" => dir,
         "LOG" => log,
@@ -116,6 +118,7 @@ RSpec.describe "Socket Firewall package-manager shim" do
       SH
       env = {
         "DOTFILES_SFW_DISABLE" => "1",
+        "DOTFILES_SFW_BIN" => File.join(real_dir, "sfw"),
         "DOTFILES_SFW_SHIM_DIR" => shim_dir,
         "HOME" => dir,
         "LOG" => log,
@@ -143,6 +146,7 @@ RSpec.describe "Socket Firewall package-manager shim" do
       write_executable(File.join(real_dir, "npm"), "#!/bin/sh\nexit 0\n")
       env = {
         "DOTFILES_SFW_SHIM_DIR" => shim_dir,
+        "DOTFILES_SFW_BIN" => File.join(real_dir, "missing-sfw"),
         "DOTFILES_SFW_REQUIRE" => "1",
         "HOME" => dir,
         "PATH" => [shim_dir, real_dir, "/bin", "/usr/bin"].join(File::PATH_SEPARATOR)
@@ -152,8 +156,8 @@ RSpec.describe "Socket Firewall package-manager shim" do
 
       expect(status.exitstatus).to eq(127)
       expect(stderr).to include(
-        "dotfiles-sfw-shim: refusing to run npm unprotected because sfw is unavailable",
-        "dotfiles-sfw-shim: install with: DOTFILES_SFW_DISABLE=1 npm i -g sfw && nodenv rehash"
+        "dotfiles-sfw-shim: refusing to run npm unprotected because DOTFILES_SFW_BIN is unavailable",
+        "dotfiles-sfw-shim: install with: script/socket-firewall install"
       )
     end
   end
@@ -166,6 +170,7 @@ RSpec.describe "Socket Firewall package-manager shim" do
       write_executable(File.join(real_dir, "npm"), "#!/bin/sh\nexit 0\n")
       env = {
         "DOTFILES_SFW_ACTIVE" => "1",
+        "DOTFILES_SFW_BIN" => File.join(real_dir, "missing-sfw"),
         "DOTFILES_SFW_SHIM_DIR" => shim_dir,
         "DOTFILES_SFW_REQUIRE" => "1",
         "HOME" => dir,
@@ -175,7 +180,7 @@ RSpec.describe "Socket Firewall package-manager shim" do
       _stdout, stderr, status = run_shim(env, shim_dir, "npm", "--version")
 
       expect(status.exitstatus).to eq(127)
-      expect(stderr).to include("dotfiles-sfw-shim: refusing to run npm unprotected because sfw is unavailable")
+      expect(stderr).to include("dotfiles-sfw-shim: refusing to run npm unprotected because DOTFILES_SFW_BIN is unavailable")
     end
   end
 end


### PR DESCRIPTION
## TL;DR 🧯
Pins the Socket Firewall Free macOS arm64 release metadata and teaches `script/install` to verify/install `~/.local/bin/sfw` without committing the binary.

The shims now call `DOTFILES_SFW_BIN` directly instead of resolving `sfw` through `PATH`, which avoids nodenv-scoped global npm installs and makes Codex/non-interactive wrappers more deterministic. The installer verifies GitHub release metadata, size, SHA256, and code signing before replacing the binary; unsigned SFW builds are rejected and quarantine state is only reported for diagnostics.