### PR TITLE
Remove Crystal shell setup

### DIFF
--- a/script/test
+++ b/script/test
@@ -190,7 +190,7 @@ for dead_path in "${dead_paths[@]}"; do
     fi
 done
 
-dead_marker_pattern="linux_server|gitconfig_linux|linuxbrew|crenv|notify-send|dircolors|/home/grantbirki|/mnt/c"
+dead_marker_pattern="linux_server|gitconfig_linux|linuxbrew|crystal|crenv|notify-send|dircolors|/home/grantbirki|/mnt/c"
 if command -v rg >/dev/null 2>&1; then
     if rg -n -i "$dead_marker_pattern" \
         --hidden \

--- a/shell/languages.bash
+++ b/shell/languages.bash
@@ -35,9 +35,3 @@ if [ -f "$CARGO_HOME/env" ]; then
   . "$CARGO_HOME/env"
 fi
 path_prepend "$CARGO_HOME/bin"
-
-# crystal
-export CRYSTAL_OPTS="--link-flags=-Wl"
-if command -v crystal >/dev/null 2>&1; then
-  export CRYSTAL_PATH="vendor/shards/install:$(crystal env CRYSTAL_PATH)"
-fi


### PR DESCRIPTION
## Summary

Remove the stale Crystal shell environment setup from `shell/languages.bash`.

Also marks `crystal` as a dead configuration marker in `script/test` so Crystal-related config does not re-enter the public dotfiles.