### PR TITLE
Map mechanical keyboard Alt to Command

### DIFF
--- a/configs/karabiner/karabiner.json
+++ b/configs/karabiner/karabiner.json
@@ -3186,7 +3186,19 @@
                         "product_id": 22019,
                         "vendor_id": 28533
                     },
-                    "ignore": false
+                    "ignore": false,
+                    "simple_modifications": [
+                        {
+                            "from": {
+                                "key_code": "left_option"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "left_command"
+                                }
+                            ]
+                        }
+                    ]
                 }
             ],
             "name": "birki",

--- a/configs/karabiner/karabiner.json
+++ b/configs/karabiner/karabiner.json
@@ -3150,16 +3150,6 @@
                     "simple_modifications": [
                         {
                             "from": {
-                                "key_code": "left_command"
-                            },
-                            "to": [
-                                {
-                                    "key_code": "left_option"
-                                }
-                            ]
-                        },
-                        {
-                            "from": {
                                 "key_code": "left_option"
                             },
                             "to": [
@@ -3178,16 +3168,6 @@
                     },
                     "ignore": false,
                     "simple_modifications": [
-                        {
-                            "from": {
-                                "key_code": "left_command"
-                            },
-                            "to": [
-                                {
-                                    "key_code": "left_option"
-                                }
-                            ]
-                        },
                         {
                             "from": {
                                 "key_code": "left_option"

--- a/configs/karabiner/karabiner.json
+++ b/configs/karabiner/karabiner.json
@@ -3146,7 +3146,59 @@
                         "product_id": 4641,
                         "vendor_id": 17498
                     },
-                    "ignore": false
+                    "ignore": false,
+                    "simple_modifications": [
+                        {
+                            "from": {
+                                "key_code": "left_command"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "left_option"
+                                }
+                            ]
+                        },
+                        {
+                            "from": {
+                                "key_code": "left_option"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "left_command"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "identifiers": {
+                        "is_keyboard": true,
+                        "product_id": 4641,
+                        "vendor_id": 17498
+                    },
+                    "ignore": false,
+                    "simple_modifications": [
+                        {
+                            "from": {
+                                "key_code": "left_command"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "left_option"
+                                }
+                            ]
+                        },
+                        {
+                            "from": {
+                                "key_code": "left_option"
+                            },
+                            "to": [
+                                {
+                                    "key_code": "left_command"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 {
                     "identifiers": {

--- a/lib/dotfiles/manifest.rb
+++ b/lib/dotfiles/manifest.rb
@@ -190,7 +190,6 @@ module Dotfiles
     def normalized_karabiner(path)
       data = JSON.parse(File.read(path))
       Array(data["profiles"]).each do |profile|
-        profile.delete("devices")
         profile.delete("virtual_hid_keyboard")
       end
       data

--- a/spec/lib/manifest_spec.rb
+++ b/spec/lib/manifest_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Dotfiles::Entry do
       target = File.join(home, ".config/karabiner/karabiner.json")
       FileUtils.mkdir_p(File.dirname(target))
       data = JSON.parse(File.read(source))
-      data.fetch("profiles").first["devices"] = [{ "identifier" => "runtime" }]
+      data.fetch("profiles").first["virtual_hid_keyboard"] = { "keyboard_type_v2" => "ansi" }
       File.write(target, JSON.pretty_generate(data))
       karabiner = described_class.new(
         "id" => "karabiner",
@@ -182,6 +182,10 @@ RSpec.describe Dotfiles::Entry do
         "compare" => "karabiner"
       )
       expect(karabiner.target_matches?).to eq(true)
+
+      data.fetch("profiles").first["devices"] = [{ "identifier" => "runtime" }]
+      File.write(target, JSON.pretty_generate(data))
+      expect(karabiner.target_matches?).to eq(false)
     end
   end
 


### PR DESCRIPTION
## Summary

Map the DZ60 mechanical keyboard physical `Alt` key to macOS `Command` on both Karabiner device records.

This makes physical `Alt+Tab` invoke native macOS app switching while preserving the physical `Windows` key for the existing `Windows+L` lock-screen shortcut.

Also keep Karabiner `devices` in the install comparison so device-specific mappings are copied onto existing machines.